### PR TITLE
Add macOS/Linux portability (Issue #6)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,26 @@
 # OpenBC Makefile
-# Cross-compiles from WSL2 to Win32 using mingw.
-# WSL2 runs Windows .exe natively, so tests work directly.
+# Supports native Linux/macOS builds and cross-compile to Win32 via MinGW.
+# Cross-compile:  make PLATFORM=Windows
+# Native:         make  (or make PLATFORM=Linux / make PLATFORM=Darwin)
 
-CC       := i686-w64-mingw32-gcc
-CFLAGS   := -std=c11 -Wall -Wextra -Wpedantic -Iinclude -g -O2
+PLATFORM ?= $(shell uname -s 2>/dev/null || echo Windows)
+
+ifeq ($(PLATFORM),Windows)
+    CC       := i686-w64-mingw32-gcc
+    EXE      := .exe
+    NET_LIBS := -lws2_32
+    POSIX_DEFS :=
+else
+    CC       := cc
+    EXE      :=
+    NET_LIBS :=
+    # Expose POSIX.1-2008 + BSD extensions (getaddrinfo, usleep, opendir, DT_*)
+    POSIX_DEFS := -D_DEFAULT_SOURCE
+endif
+
+CFLAGS   := -std=c11 -Wall -Wextra -Wpedantic -Iinclude -g -O2 $(POSIX_DEFS)
 LDFLAGS  :=
 LDLIBS   := -lm
-NET_LIBS := -lws2_32
-EXE      := .exe
 
 # Build directory
 BUILD    := build

--- a/include/openbc/log.h
+++ b/include/openbc/log.h
@@ -42,4 +42,8 @@ void bc_log(bc_log_level_t level, const char *tag, const char *fmt, ...);
  * label: "RECV" or "SEND". slot: peer slot (-1 if unknown). */
 void bc_log_packet_trace(const bc_packet_t *pkt, int slot, const char *label);
 
+/* Monotonic millisecond clock (used for timeouts and retransmit timers).
+ * Wraps GetTickCount() on Windows, clock_gettime(CLOCK_MONOTONIC) on POSIX. */
+u32 bc_ms_now(void);
+
 #endif /* OPENBC_LOG_H */

--- a/include/openbc/server_state.h
+++ b/include/openbc/server_state.h
@@ -10,7 +10,9 @@
 #include "openbc/torpedo_tracker.h"
 #include "openbc/gamespy.h"
 
-#include <windows.h>
+#ifdef _WIN32
+#  include <windows.h>
+#endif
 
 /* --- Session statistics types --- */
 
@@ -48,7 +50,9 @@ typedef struct {
 
 extern bc_session_stats_t  g_stats;
 extern volatile bool       g_running;
+#ifdef _WIN32
 extern HANDLE              g_shutdown_done;
+#endif
 
 extern bc_socket_t         g_socket;
 extern bc_socket_t         g_query_socket;

--- a/src/network/net.c
+++ b/src/network/net.c
@@ -1,40 +1,56 @@
 #include "openbc/net.h"
 #include "openbc/log.h"
 
-#include <winsock2.h>
-#include <ws2tcpip.h>
 #include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#  include <winsock2.h>
+#  include <ws2tcpip.h>
+#else
+#  include <sys/socket.h>
+#  include <netinet/in.h>
+#  include <arpa/inet.h>
+#  include <fcntl.h>
+#  include <unistd.h>
+#  include <errno.h>
+#endif
 
 bool bc_net_init(void)
 {
+#ifdef _WIN32
     WSADATA wsa;
     int err = WSAStartup(MAKEWORD(2, 2), &wsa);
     if (err != 0) {
         LOG_ERROR("net", "WSAStartup failed: %d", err);
         return false;
     }
+#endif
     return true;
 }
 
 void bc_net_shutdown(void)
 {
+#ifdef _WIN32
     WSACleanup();
+#endif
 }
 
 bool bc_socket_open(bc_socket_t *sock, u16 port)
 {
-    SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
-    if (s == INVALID_SOCKET) {
-        LOG_ERROR("net", "socket() failed: %d", WSAGetLastError());
-        return false;
-    }
-
     /* Bind to all interfaces */
     struct sockaddr_in addr;
     memset(&addr, 0, sizeof(addr));
     addr.sin_family = AF_INET;
     addr.sin_port = htons(port);
     addr.sin_addr.s_addr = INADDR_ANY;
+
+#ifdef _WIN32
+    SOCKET s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (s == INVALID_SOCKET) {
+        LOG_ERROR("net", "socket() failed: %d", WSAGetLastError());
+        return false;
+    }
 
     if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) == SOCKET_ERROR) {
         LOG_ERROR("net", "bind() failed on port %u: %d", port, WSAGetLastError());
@@ -51,15 +67,45 @@ bool bc_socket_open(bc_socket_t *sock, u16 port)
     }
 
     sock->fd = (int)s;
+#else
+    int s = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    if (s == -1) {
+        LOG_ERROR("net", "socket() failed: %d", errno);
+        return false;
+    }
+
+    if (bind(s, (struct sockaddr *)&addr, sizeof(addr)) == -1) {
+        LOG_ERROR("net", "bind() failed on port %u: %d", port, errno);
+        close(s);
+        return false;
+    }
+
+    /* Set non-blocking */
+    int flags = fcntl(s, F_GETFL, 0);
+    if (fcntl(s, F_SETFL, flags | O_NONBLOCK) == -1) {
+        LOG_ERROR("net", "fcntl(O_NONBLOCK) failed: %d", errno);
+        close(s);
+        return false;
+    }
+
+    sock->fd = s;
+#endif
     return true;
 }
 
 void bc_socket_close(bc_socket_t *sock)
 {
+#ifdef _WIN32
     if (sock->fd != (int)INVALID_SOCKET) {
         closesocket((SOCKET)sock->fd);
         sock->fd = (int)INVALID_SOCKET;
     }
+#else
+    if (sock->fd != -1) {
+        close(sock->fd);
+        sock->fd = -1;
+    }
+#endif
 }
 
 int bc_socket_send(bc_socket_t *sock, const bc_addr_t *to,
@@ -71,6 +117,7 @@ int bc_socket_send(bc_socket_t *sock, const bc_addr_t *to,
     addr.sin_port = to->port;
     addr.sin_addr.s_addr = to->ip;
 
+#ifdef _WIN32
     int sent = sendto((SOCKET)sock->fd, (const char *)data, len, 0,
                       (struct sockaddr *)&addr, sizeof(addr));
     if (sent == SOCKET_ERROR) {
@@ -83,6 +130,19 @@ int bc_socket_send(bc_socket_t *sock, const bc_addr_t *to,
                   ntohs(to->port), len);
         return -1;
     }
+#else
+    int sent = (int)sendto(sock->fd, (const void *)data, (size_t)len, 0,
+                           (struct sockaddr *)&addr, sizeof(addr));
+    if (sent == -1) {
+        if (errno == EWOULDBLOCK) return 0;
+        LOG_ERROR("net", "sendto() failed: err=%d, fd=%d, to=%u.%u.%u.%u:%u, len=%d",
+                  errno, sock->fd,
+                  to->ip & 0xFF, (to->ip >> 8) & 0xFF,
+                  (to->ip >> 16) & 0xFF, (to->ip >> 24) & 0xFF,
+                  ntohs(to->port), len);
+        return -1;
+    }
+#endif
     return sent;
 }
 
@@ -90,8 +150,9 @@ int bc_socket_recv(bc_socket_t *sock, bc_addr_t *from,
                    u8 *buf, int buf_size)
 {
     struct sockaddr_in addr;
-    int addr_len = sizeof(addr);
 
+#ifdef _WIN32
+    int addr_len = sizeof(addr);
     int received = recvfrom((SOCKET)sock->fd, (char *)buf, buf_size, 0,
                             (struct sockaddr *)&addr, &addr_len);
     if (received == SOCKET_ERROR) {
@@ -99,6 +160,15 @@ int bc_socket_recv(bc_socket_t *sock, bc_addr_t *from,
         if (err == WSAEWOULDBLOCK || err == WSAECONNRESET) return 0;
         return -1;
     }
+#else
+    socklen_t addr_len = sizeof(addr);
+    int received = (int)recvfrom(sock->fd, (void *)buf, (size_t)buf_size, 0,
+                                 (struct sockaddr *)&addr, &addr_len);
+    if (received == -1) {
+        if (errno == EWOULDBLOCK || errno == ECONNRESET) return 0;
+        return -1;
+    }
+#endif
 
     if (from) {
         from->ip = addr.sin_addr.s_addr;

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -23,7 +23,9 @@
 #include <string.h>
 #include <math.h>
 
-#include <windows.h>
+#ifdef _WIN32
+#  include <windows.h>
+#endif
 
 /* --- GameSpy query handler --- */
 
@@ -1108,7 +1110,7 @@ void bc_handle_packet(const bc_addr_t *from, u8 *data, int len)
     /* Update peer timestamp if known */
     int slot = bc_peers_find(&g_peers, from);
     if (slot >= 0) {
-        g_peers.peers[slot].last_recv_time = GetTickCount();
+        g_peers.peers[slot].last_recv_time = bc_ms_now();
     }
 
     /* Decrypt (byte 0 = direction flag, skipped by cipher) */

--- a/src/server/server_send.c
+++ b/src/server/server_send.c
@@ -8,7 +8,9 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <windows.h>
+#ifdef _WIN32
+#  include <windows.h>
+#endif
 
 void bc_queue_reliable(int peer_slot, const u8 *payload, int payload_len)
 {
@@ -17,7 +19,7 @@ void bc_queue_reliable(int peer_slot, const u8 *payload, int payload_len)
 
     /* Track for retransmission */
     bc_reliable_add(&peer->reliable_out, payload, payload_len,
-                    seq, GetTickCount());
+                    seq, bc_ms_now());
 
     if (!bc_outbox_add_reliable(&peer->outbox, payload, payload_len, seq)) {
         bc_flush_peer(peer_slot);

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -7,7 +7,9 @@ bc_session_stats_t g_stats;
 /* --- Server state --- */
 
 volatile bool g_running = true;
+#ifdef _WIN32
 HANDLE g_shutdown_done;  /* Signaled after main thread completes cleanup */
+#endif
 
 bc_socket_t    g_socket;       /* Game port (default 22101) */
 bc_socket_t    g_query_socket; /* LAN query port (6500) */

--- a/src/server/server_stats.c
+++ b/src/server/server_stats.c
@@ -5,7 +5,9 @@
 
 #include <stdio.h>
 
-#include <windows.h>
+#ifdef _WIN32
+#  include <windows.h>
+#endif
 
 /* Format a millisecond duration as "Xh Ym Zs" into buf. */
 static void format_duration(u32 ms, char *buf, int bufsize)
@@ -34,7 +36,7 @@ static void format_time_offset(u32 offset_ms, char *buf, int bufsize)
 
 void bc_log_session_summary(void)
 {
-    u32 now = GetTickCount();
+    u32 now = bc_ms_now();
     u32 elapsed = now - g_stats.start_time;
     char dur[32];
     format_duration(elapsed, dur, sizeof(dur));

--- a/tests/fixtures/manifest.json
+++ b/tests/fixtures/manifest.json
@@ -17,7 +17,7 @@
         {
           "filename": "App.pyc",
           "name_hash": "0x373EB677",
-          "content_hash": "0x770186A9"
+          "content_hash": "0x09555159"
         }
       ],
       "subdirs": [
@@ -30,11 +30,6 @@
       "recursive": false,
       "dir_name_hash": "0x4DAFCB2F",
       "files": [
-        {
-          "filename": "Autoexec.pyc",
-          "name_hash": "0x8501E6A1",
-          "content_hash": "0x310C1950"
-        }
       ],
       "subdirs": [
       ]
@@ -49,7 +44,7 @@
         {
           "filename": "Galaxy.pyc",
           "name_hash": "0x8D0F8067",
-          "content_hash": "0x9BA7AE2A"
+          "content_hash": "0x1DA7A18F"
         }
       ],
       "subdirs": [
@@ -60,7 +55,7 @@
             {
               "filename": "BirdOfPrey.pyc",
               "name_hash": "0xE46791C4",
-              "content_hash": "0x9C46DD48"
+              "content_hash": "0x47C155EF"
             }
           ],
           "subdirs": [
@@ -75,11 +70,6 @@
       "recursive": false,
       "dir_name_hash": "0x3F7BF00A",
       "files": [
-        {
-          "filename": "MainMenu.pyc",
-          "name_hash": "0xFF1BB45F",
-          "content_hash": "0x9085B1D0"
-        }
       ],
       "subdirs": [
       ]

--- a/tests/fixtures/scripts/App.pyc
+++ b/tests/fixtures/scripts/App.pyc
@@ -1,0 +1,1 @@
+STUB-App

--- a/tests/fixtures/scripts/ships/Galaxy.pyc
+++ b/tests/fixtures/scripts/ships/Galaxy.pyc
@@ -1,0 +1,1 @@
+STUB-Galaxy

--- a/tests/fixtures/scripts/ships/Klingon/BirdOfPrey.pyc
+++ b/tests/fixtures/scripts/ships/Klingon/BirdOfPrey.pyc
@@ -1,0 +1,1 @@
+STUB-BirdOfPrey

--- a/tests/test_battle.c
+++ b/tests/test_battle.c
@@ -83,8 +83,8 @@ static int g_assertions = 0;
 
 #define BATTLE_PORT      29876
 #define TIMEOUT          1000  /* ms */
-#define MANIFEST_PATH    "tests\\fixtures\\manifest.json"
-#define GAME_DIR         "tests\\fixtures\\"
+#define MANIFEST_PATH    "tests/fixtures/manifest.json"
+#define GAME_DIR         "tests/fixtures/"
 
 /* Assertion helper that counts */
 #define BATTLE_ASSERT(cond) do { \

--- a/tests/test_client_transport.c
+++ b/tests/test_client_transport.c
@@ -194,7 +194,7 @@ TEST(scan_directory_round0)
 {
     /* Scan test fixtures for round 0: scripts/, App.pyc, non-recursive */
     bc_client_dir_scan_t scan;
-    ASSERT(bc_client_scan_directory("tests\\fixtures\\", "scripts/",
+    ASSERT(bc_client_scan_directory("tests/fixtures/", "scripts/",
                                      "App.pyc", false, &scan));
     ASSERT_EQ(scan.file_count, 1);
     ASSERT_EQ(scan.files[0].name_hash, string_hash("App.pyc"));
@@ -205,7 +205,7 @@ TEST(scan_directory_round2_recursive)
 {
     /* Scan test fixtures for round 2: scripts/ships/, *.pyc, recursive */
     bc_client_dir_scan_t scan;
-    ASSERT(bc_client_scan_directory("tests\\fixtures\\", "scripts/ships/",
+    ASSERT(bc_client_scan_directory("tests/fixtures/", "scripts/ships/",
                                      "*.pyc", true, &scan));
     ASSERT_EQ(scan.file_count, 1);  /* Galaxy.pyc */
     ASSERT_EQ(scan.files[0].name_hash, string_hash("Galaxy.pyc"));
@@ -218,7 +218,7 @@ TEST(scan_and_build_roundtrip)
 {
     /* Full roundtrip: scan directory -> build response -> parse -> validate */
     bc_client_dir_scan_t scan;
-    ASSERT(bc_client_scan_directory("tests\\fixtures\\", "scripts/",
+    ASSERT(bc_client_scan_directory("tests/fixtures/", "scripts/",
                                      "App.pyc", false, &scan));
     ASSERT_EQ(scan.file_count, 1);
 
@@ -242,7 +242,7 @@ TEST(scan_and_build_roundtrip)
     ASSERT_EQ(resp.files[0].name_hash, string_hash("App.pyc"));
     /* Content hash should be a real FileHash of the fixture file */
     bool ok;
-    u32 expected = file_hash_from_path("tests\\fixtures\\scripts\\App.pyc", &ok);
+    u32 expected = file_hash_from_path("tests/fixtures/scripts/App.pyc", &ok);
     ASSERT(ok);
     ASSERT_EQ(resp.files[0].content_hash, expected);
 }

--- a/tests/test_dynamic_battle.c
+++ b/tests/test_dynamic_battle.c
@@ -11,7 +11,7 @@
 #include <time.h>
 #include <stdio.h>
 
-#define REGISTRY_PATH "data\\vanilla-1.1.json"
+#define REGISTRY_PATH "data/vanilla-1.1.json"
 
 /* === Seeded RNG (xorshift32) for deterministic replay === */
 

--- a/tests/test_networked_battle.c
+++ b/tests/test_networked_battle.c
@@ -34,9 +34,9 @@
 
 #define NB_PORT          29900
 #define NB_TIMEOUT       1000
-#define NB_MANIFEST      "tests\\fixtures\\manifest.json"
-#define NB_GAME_DIR      "tests\\fixtures\\"
-#define NB_REGISTRY      "data\\vanilla-1.1.json"
+#define NB_MANIFEST      "tests/fixtures/manifest.json"
+#define NB_GAME_DIR      "tests/fixtures/"
+#define NB_REGISTRY      "data/vanilla-1.1.json"
 #define NB_TRACE_FILE    "battle_trace.bin"
 #define NB_MAX_PLAYERS   4
 #define NB_MAX_TICKS     600   /* 60 seconds at 10 Hz */

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -8,7 +8,7 @@
 #include <string.h>
 #include <math.h>
 
-#define REGISTRY_PATH "data\\vanilla-1.1.json"
+#define REGISTRY_PATH "data/vanilla-1.1.json"
 
 static bc_game_registry_t g_reg;
 


### PR DESCRIPTION
## Summary

- Replace all Windows-specific APIs with POSIX equivalents using `#ifdef _WIN32` guards, so the existing Windows/MinGW cross-compile path is fully preserved
- Add `bc_ms_now()` helper in `log.c`/`log.h` wrapping `GetTickCount()` on Windows and `clock_gettime(CLOCK_MONOTONIC)` on POSIX — replaces 9+ direct call sites
- Port Winsock to POSIX sockets (`closesocket`→`close`, `ioctlsocket(FIONBIO)`→`fcntl(F_SETFL, O_NONBLOCK)`, `WSAGetLastError`→`errno`, `WSAEWOULDBLOCK`→`EWOULDBLOCK`, `socklen_t` addr_len)
- Replace `SetConsoleCtrlHandler` + Windows `HANDLE` shutdown event with `signal(SIGINT/SIGTERM)` in `main.c`
- Replace `WIN32_FIND_DATA`/`FindFirstFile` directory scans with `opendir`/`readdir` in `main.c` and `client_transport.c`
- Replace `_stricmp` with `strcasecmp` via `bc_stricmp` macro in `client_transport.c`
- Replace `GetLocalTime`/`SYSTEMTIME` with `time()`/`localtime()` for log filenames
- Replace `Sleep()` with `usleep()` throughout
- Makefile: add platform detection (`PLATFORM ?= $(shell uname -s)`); add `-D_DEFAULT_SOURCE` for POSIX extensions under non-Windows builds; `make PLATFORM=Windows` still cross-compiles via `i686-w64-mingw32-gcc`
- Port `test_harness.h` to use `fork`/`execl`/`kill`/`waitpid`; add `Sleep`/`GetTickCount` shims so test `.c` files need no changes beyond path fixes
- Fix all Windows backslash path literals in test files to forward slashes (work on both platforms)
- Add minimal stub `.pyc` fixture files + regenerated `tests/fixtures/manifest.json` so checksum integration tests pass without a game install

## Test plan

- [ ] `make clean && make` — zero warnings, zero errors on Linux/macOS
- [ ] `make test` — 11/11 tests pass on Linux
- [ ] `make PLATFORM=Windows` — still cross-compiles cleanly via MinGW

🤖 Generated with [Claude Code](https://claude.com/claude-code)