### PR TITLE
Collision damage rework, power system fixes, PythonEvent support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _deps/
 # MCP config (user-specific)
 .mcp.json
 server_*.log
+openbc-*.log
 battle_trace.bin
 
 mods/*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,9 @@ Open-source, standalone multiplayer server for Star Trek: Bridge Commander (2002
 | Component | Choice | Rationale |
 |-----------|--------|-----------|
 | Language | C (core) + Python 3 (tooling) | Performance-critical server; Python for build tools |
-| Build | Make | Simple, proven, cross-compiles from WSL2 |
+| Build | Make | Simple, proven; native on Linux/macOS, cross-compiles to Win32 via MinGW |
 | Data | JSON (machine-generated) | Ship/projectile registry, hash manifests |
-| Networking | Raw UDP (Winsock) | Wire-compatible with stock BC clients |
+| Networking | Raw UDP (Winsock / BSD sockets) | Wire-compatible with stock BC clients |
 
 ## Development Phases
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ else
 endif
 
 CFLAGS   := -std=c11 -Wall -Wextra -Wpedantic -Iinclude -g -O2 $(POSIX_DEFS)
+DEPFLAGS  = -MMD -MP -MF $(@:.o=.d)
 LDFLAGS  :=
 LDLIBS   := -lm
 
@@ -96,7 +97,10 @@ $(BUILD)/tests/test_%$(EXE): tests/test_%.c $(LIB_OBJ)
 # --- Generic object compilation ---
 $(BUILD)/%.o: %.c
 	@mkdir -p $(@D)
-	$(CC) $(CFLAGS) -c -o $@ $<
+	$(CC) $(CFLAGS) $(DEPFLAGS) -c -o $@ $<
+
+# Include auto-generated header dependencies
+-include $(wildcard $(BUILD)/src/**/*.d $(BUILD)/tools/*.d)
 
 # --- Copy data files into build directory ---
 $(BUILD)/data: data

--- a/docs/collision-damage-event-chain.md
+++ b/docs/collision-damage-event-chain.md
@@ -105,8 +105,8 @@ The multiplayer game object registers a handler for ADD_TO_REPAIR_LIST events (a
 4. Sends it to the **"NoMe"** routing group (all peers except the host itself)
 
 The HostEventHandler also handles two other event types using the same pattern:
-- **REPAIR_COMPLETE** — when a subsystem finishes repairing
-- **REPAIR_CANCELLED** — when a repair is cancelled
+- **REPAIR_COMPLETE** — when a subsystem's condition reaches maximum (repair finished)
+- **REPAIR_CANNOT_BE_COMPLETED** — when a subsystem is destroyed while in the repair queue (condition reaches 0.0)
 
 All three produce opcode 0x06 messages with identical framing; only the serialized event type differs.
 

--- a/docs/collision-shield-interaction.md
+++ b/docs/collision-shield-interaction.md
@@ -1,0 +1,154 @@
+# Collision-Shield Interaction
+
+How collision damage interacts with shields in Bridge Commander multiplayer, documented from observable behavior, network packet captures, and the game's shipped Python scripting API.
+
+**Clean room statement**: This document describes collision-shield interaction as observable gameplay behavior. No binary addresses, memory offsets, or decompiled code are referenced.
+
+---
+
+## Overview
+
+Collision damage does **not** bypass shields. Shields absorb collision damage directionally — the shield facing closest to the impact point absorbs damage first, and only overflow reaches hull and subsystems.
+
+However, collision damage interacts with shields differently than weapons or explosions. The three damage paths each have distinct shield behavior.
+
+---
+
+## Three Damage Paths and Their Shield Behavior
+
+### 1. Collision Damage: Directional Per-Subsystem Absorption
+
+When a collision occurs:
+
+1. The engine finds all subsystems (including shield facings) near the collision point
+2. Each subsystem absorbs damage from its HP pool
+3. Shield facings absorb damage like any other subsystem — based on spatial proximity to the impact point
+4. Whatever damage shields and subsystems don't absorb flows through to hull structural damage
+
+**Key characteristics:**
+- **Directional**: A head-on collision primarily drains front shields, not all facings equally
+- **No pre-filter**: 100% of collision damage enters the subsystem damage pipeline (unlike weapons which have a shield gate)
+- **Power subsystem exposed**: Collisions can directly damage the reactor/power subsystem; weapons exclude it
+- **Per-contact**: Multi-contact collisions apply damage once per contact point, each going through shield absorption independently
+
+### 2. Weapon Damage: Binary Shield Gate + Per-Subsystem
+
+When a weapon hits:
+
+1. **Pre-filter (binary gate)**: The engine traces the weapon's ray against the shield ellipsoid. If the ray intersects and the shield facing has HP, the hit is **fully absorbed** — no damage reaches hull at all
+2. About 72% of weapon hits are stopped at this gate (observed in stock 3-player combat)
+3. If the weapon passes through (shield facing depleted, or angle/geometry allows penetration), damage enters the same per-subsystem pipeline as collisions
+4. Weapon damage **excludes the power subsystem** from the hit list when multiple subsystems are in range
+
+### 3. Explosion Damage: Uniform Area-Effect
+
+When a ship explodes (area-of-effect):
+
+1. **Uniform shield drain**: Damage is divided equally across all 6 shield facings (1/6 each)
+2. Each facing independently absorbs up to its current HP for its share
+3. Whatever isn't absorbed by shields flows through to subsystem/hull damage
+4. A ship with 5 full facings and 1 empty facing still loses 1/6 of the damage to hull
+
+---
+
+## Comparison Table
+
+| Aspect | Collision | Weapon | AoE Explosion |
+|--------|-----------|--------|---------------|
+| Shield check | Directional (per-subsystem) | Binary gate + per-subsystem | Uniform 1/6 per facing |
+| Shield bypass rate | 0% bypass (always checked) | ~72% absorbed at gate | 0% bypass (always checked) |
+| Damage reach rate | 100% enters pipeline | ~28% enters pipeline | 100% enters pipeline |
+| Power subsystem hit? | Yes | No (excluded from list) | Yes (via subsystem path) |
+| Facing selectivity | Impact-facing only | Hit-facing only | All 6 equally |
+| Contact multiplication | Per-contact point | Single hit | Single area |
+
+---
+
+## Observable Consequences
+
+### Why Collisions Feel Powerful
+
+- **No shield gate**: Every collision enters the damage pipeline. Weapons lose 72% at the shield gate.
+- **Multiple contacts**: A collision can produce 2+ contact points, each applying damage independently through shield absorption. This can overwhelm a single shield facing in one physics tick.
+- **Power subsystem exposed**: Collisions can hit the warp core directly, potentially cascading into power failures.
+
+### Shield Facing Depletion Pattern
+
+A head-on collision at full speed:
+- **Front shields** absorb the impact; other facings are unaffected
+- If front shields are depleted, overflow immediately hits hull + subsystems in the forward arc
+- Rear shields remain at 100% even as the ship takes serious forward damage
+
+This is different from explosions, which drain all facings equally regardless of direction.
+
+### Stock Trace Data (15-minute 3-player session)
+
+| Metric | Value |
+|--------|-------|
+| Collision checks | 79,605 |
+| Actual collision damage events | 229 (0.3% trigger rate) |
+| Weapon hits | 1,939 |
+| Weapon hits past shields | 536 (28% pass rate) |
+| Total damage events reaching subsystems | 765 (536 weapon + 229 collision) |
+
+---
+
+## Server Implementation Notes
+
+### Current Bug: Area-Effect Used for Collisions
+
+The current OpenBC implementation uses area-effect shield absorption (damage/6 per facing) for collision damage. This is **incorrect** — it matches the explosion path, not the collision path.
+
+**What stock does**: Directional absorption — find the shield facing(s) nearest the collision point, absorb damage from those facings only, pass overflow to hull/subsystems.
+
+**What OpenBC does**: Uniform absorption — divide damage by 6, absorb from all facings equally. This means:
+- Shields absorb ALL collision damage (total shield pool is huge when spread across 6 facings)
+- Hull and subsystems never take damage from collisions (shields absorb everything)
+- Client sees directional shield drain locally but server disagrees → flickering
+
+### Required Fix
+
+Switch collision damage from area-effect to directed shield absorption:
+
+1. Determine which shield facing the collision impacts (from the impact direction vector)
+2. Absorb damage from that facing's HP
+3. If facing is depleted, overflow goes to hull and nearby subsystems
+4. Do NOT distribute across all 6 facings
+
+### Shield Facing Determination
+
+The facing is determined by the dominant component of the impact direction in ship-local space:
+
+| Direction | Facing |
+|-----------|--------|
+| +Y (forward) | Front |
+| -Y (aft) | Rear |
+| +Z (up) | Top |
+| -Z (down) | Bottom |
+| +X (starboard) | Right |
+| -X (port) | Left |
+
+This is a maximum-component test (equivalent to cube face selection), not a dot-product projection. See [shield-system docs](../../STBC-Dedicated-Server/docs/shield-system.md) for the full algorithm.
+
+### Power Subsystem Exclusion
+
+The stock game excludes the power subsystem (reactor/warp core) from the subsystem hit list for weapon damage but NOT for collision damage. This means collisions can directly damage the reactor, potentially causing cascading power failures. The `isCollision` flag controls this behavior.
+
+---
+
+## Wire Format Impact
+
+Collision damage uses the same network messages as other damage types:
+- **Opcode 0x15** (CollisionEffect): Client → Host, carries collision force and contact points
+- **Flag 0x20** (StateUpdate): Host → Client, carries authoritative subsystem conditions
+- **Opcode 0x06** (PythonEvent): Host → Client, carries ADD_TO_REPAIR_LIST events per damaged subsystem
+
+The server must correctly apply directional shield absorption when processing opcode 0x15, then send the resulting subsystem conditions via flag 0x20 health updates and repair events via opcode 0x06.
+
+---
+
+## Relationship to Other Docs
+
+- [collision-damage-event-chain.md](collision-damage-event-chain.md) — How collision damage generates PythonEvent messages (the event chain after damage is applied)
+- [collision-effect-wire-format.md](../../STBC-Dedicated-Server/docs/collision-effect-protocol.md) — Opcode 0x15 wire format
+- [pythonevent-wire-format.md](pythonevent-wire-format.md) — Opcode 0x06 wire format for subsystem damage events

--- a/docs/fix-collision-shield-absorption.md
+++ b/docs/fix-collision-shield-absorption.md
@@ -1,0 +1,125 @@
+# Fix: Collision Damage Should Use Directed Shield Absorption
+
+**Status**: Open bug
+**Affects**: `src/game/combat.c`, `src/server/server_dispatch.c`
+**Related**: [collision-shield-interaction.md](collision-shield-interaction.md), [collision-damage-event-chain.md](collision-damage-event-chain.md)
+
+---
+
+## Problem
+
+Collision damage currently uses area-effect shield absorption (`area_effect=true`), which divides damage equally across all 6 shield facings. This is incorrect — it matches the explosion/AoE path, not the collision path.
+
+### Observable Symptoms
+
+1. **Ships are invulnerable to collision damage.** With a Sovereign's 55,500 total shield HP spread across 6 facings (5,500 to 11,000 each), a typical collision dealing 6,000 damage is spread as 1,000 per facing. Every facing absorbs its share completely. Zero overflow reaches hull or subsystems.
+
+2. **Zero PythonEvent (0x06) messages after collisions.** Since no subsystems take damage, no ADD_TO_REPAIR_LIST events are generated. Clients never see repair queue updates.
+
+3. **Shield flickering.** The client's local engine applies collision damage directionally (front shields absorb on a head-on hit). But the server reports all subsystems at full health (because no damage penetrated). Client and server disagree, causing visible shield flickering.
+
+### Root Cause
+
+In `server_dispatch.c`, both collision damage call sites pass `area_effect=true`:
+
+```c
+// Target ship (line ~996)
+bc_combat_apply_damage(&target->ship, tcls, dmg, 6000.0f,
+                       impact_dir, true);    // <-- BUG: should be false
+
+// Source ship (line ~1124)
+bc_combat_apply_damage(&source->ship, scls, sdmg,
+                       6000.0f, src_impact, true);  // <-- BUG: should be false
+```
+
+The `area_effect=true` path in `bc_combat_apply_damage` divides damage by 6 and absorbs from all facings uniformly. The `area_effect=false` path finds the single impacted facing and absorbs from that facing only.
+
+---
+
+## Stock Game Behavior
+
+The stock game processes collision damage in two sequential steps:
+
+### Step 1: Subsystem Damage Distribution (includes shield absorption)
+
+The engine finds all subsystems (including shield facings) near the collision point using the ship's subsystem linked list. Each subsystem in range absorbs damage from its HP pool. Shield facings absorb damage like any other subsystem. The total damage is **reduced in-place** — whatever shields and subsystems absorb is subtracted from the original damage amount.
+
+### Step 2: Hull/Structural Damage
+
+The **reduced** damage (after shield/subsystem absorption) enters the hull damage pipeline. The engine creates a damage volume from the impact point and radius, runs AABB overlap tests against subsystem bounding boxes, and distributes remaining damage to hull and overlapping subsystems.
+
+### Key Behavioral Differences from Weapons
+
+| Aspect | Collision | Weapon | AoE Explosion |
+|--------|-----------|--------|---------------|
+| Shield absorption | Directed: impact-facing only | Binary gate (72% absorbed) + directed | Uniform 1/6 per facing |
+| Power subsystem | IN hit list (can be damaged) | EXCLUDED from hit list | IN hit list |
+| Contact points | Per-contact (damage divided) | Single hit | Single area |
+
+---
+
+## Fix
+
+### Change 1: Collision call sites — `server_dispatch.c`
+
+Change both collision damage calls from `area_effect=true` to `area_effect=false`:
+
+**Target ship** (in the CollisionEffect handler, where target ship takes damage):
+```c
+bc_combat_apply_damage(&target->ship, tcls, dmg, 6000.0f,
+                       impact_dir, false);   // directed, not area-effect
+```
+
+**Source ship** (same handler, where source ship also takes damage in ship-vs-ship collisions):
+```c
+bc_combat_apply_damage(&source->ship, scls, sdmg,
+                       6000.0f, src_impact, false);  // directed, not area-effect
+```
+
+That's it. No changes needed to `combat.c` or `combat.h`.
+
+### Why This Works
+
+The existing `area_effect=false` path in `bc_combat_apply_damage` already implements correct directed shield absorption:
+
+1. **`bc_combat_shield_facing()`** determines which shield facing the impact hits, using the maximum-component test on the impact direction in ship-local space.
+
+2. **Single-facing absorption**: Damage is absorbed from that one facing's HP. If the facing has enough HP, all damage is absorbed and the function returns (no hull/subsystem damage).
+
+3. **Overflow**: If the facing's HP is less than the damage, it's depleted to 0 and the overflow proceeds to hull damage and subsystem AABB overlap testing.
+
+This matches the stock game's collision behavior:
+- Head-on collision drains **front shields only** (not all 6 facings)
+- Front shields can be depleted while other facings remain full
+- Once front shields are depleted, overflow immediately hits hull + subsystems
+- Rear shields unaffected even during severe forward damage
+
+### Verification
+
+After the fix, observe:
+- Collision damage should reduce the impacted shield facing, not all 6 equally
+- When the impacted facing is depleted, hull HP should decrease
+- Subsystems in the collision area should take damage (subsystem_hp values decrease)
+- PythonEvent (0x06) ADD_TO_REPAIR_LIST messages should appear after collisions (~7 per ship per collision)
+- No more shield flickering — server and client agree on directional shield drain
+
+---
+
+## Power Subsystem Exclusion (Separate Issue)
+
+The stock game has a secondary behavioral difference for collisions: the power subsystem (reactor/warp core) stays in the hit list for collisions but is excluded for weapon damage when multiple subsystems are hit. This means collisions can directly damage the reactor, potentially causing cascading power failures.
+
+Currently, `bc_combat_find_hit_subsystems` does not exclude any subsystem types, which is **correct for collision damage** but **incorrect for weapon damage**. The weapon exclusion is a separate bug and should be tracked independently.
+
+If implementing power subsystem exclusion for weapons later, add a `bool is_collision` parameter to `bc_combat_apply_damage` (or `bc_combat_find_hit_subsystems`). When `false` (weapon) and more than one subsystem is in the hit list, remove the power subsystem. When `true` (collision), keep all subsystems.
+
+---
+
+## Summary of Changes
+
+| File | Change | Lines |
+|------|--------|-------|
+| `src/server/server_dispatch.c` | `area_effect=true` -> `false` for target collision | ~996-997 |
+| `src/server/server_dispatch.c` | `area_effect=true` -> `false` for source collision | ~1124-1125 |
+
+Two lines changed. No API changes. No new functions.

--- a/docs/power-system.md
+++ b/docs/power-system.md
@@ -121,6 +121,75 @@ The efficiency ratio scales subsystem performance:
 
 ---
 
+## Power Initialization on Ship Spawn
+
+Every ship spawns with all subsystems at 100% power, batteries full, and all consumers enabled. The initialization sequence establishes these defaults at three levels:
+
+1. **Constructor defaults**: Every powered subsystem is constructed with `powerPercentageWanted = 1.0` (100%), `isOn = true`, `powerMode = 0` (main-first), `efficiency = 1.0`, and `conditionRatio = 1.0`. No explicit setter call is needed — the 100% default is baked into object construction.
+
+2. **Property setup**: When the subsystem is configured from its hardpoint definition, it reads the already-set 100% value and computes `powerWanted = normalPowerPerSecond * 1.0`. The EPS distributor fills both batteries to their maximum capacity at this stage: `mainBatteryPower = MainBatteryLimit`, `backupBatteryPower = BackupBatteryLimit`.
+
+3. **Ship-level safety**: After all subsystems are constructed and linked, the ship object redundantly calls `SetPowerPercentageWanted(1.0)` on every powered subsystem as a safety net.
+
+4. **Reactor enable guard**: When the reactor subsystem is enabled, if `powerPercentageWanted <= 0.0`, it is forced to 1.0. This prevents a subsystem from remaining at 0% after being re-enabled.
+
+**Summary**: On spawn, every slider is at 100%, every subsystem is ON, batteries are full, and all consumers use draw mode 0 (main-first). This is what the player sees on the F5 Engineering panel immediately after spawning.
+
+---
+
+## Player Power Adjustment
+
+Players adjust power distribution via the F5 Engineering panel (Power Transmission Grid). Two input paths converge on the same setter method.
+
+### Input Path A: Mouse Slider
+
+The drag-adjustable slider bars in the F5 panel map directly to `SetPowerPercentageWanted(newValue)` for the target subsystem. When weapons or engines are adjusted, all subsystems in that group are synced to the same value (phasers + torpedoes + pulse weapons, or impulse + warp).
+
+### Input Path B: Keyboard Hotkeys
+
+Keyboard shortcuts fire a `MANAGE_POWER` event. The event's integer parameter encodes both the subsystem group and the adjustment direction:
+
+| Key Event Int | Group | Direction |
+|---------------|-------|-----------|
+| 0 | Weapons | Decrease (−25%) |
+| 1 | Weapons | Increase (+25%) |
+| 2 | Engines | Decrease (−25%) |
+| 3 | Engines | Increase (+25%) |
+| 4 | Sensors | Decrease (−25%) |
+| 5 | Sensors | Increase (+25%) |
+| 6 | Shields | Decrease (−25%) |
+| 7 | Shields | Increase (+25%) |
+
+**Encoding**: `int / 2` = group (0=weapons, 1=engines, 2=sensors, 3=shields), `int % 2` = direction (0=decrease, 1=increase). Values ≥ 8 are ignored.
+
+### Valid Range: 0%–125%
+
+The power percentage range is **0.0 to 1.25** (0% to 125%):
+
+- **Keyboard**: Explicit clamping at 0.0 and 1.25
+- **Slider**: C++ widget validates against the 1.25 maximum
+- **Network**: Power byte encodes as `(int)(pct * 100)`, practical range 0–125
+- **Server**: Does **NOT** enforce bounds — applies whatever the client sends
+
+The 125% overload mechanic allows "overclocking" a subsystem beyond its rated power consumption. This increases demand above the ship's normal power budget, accelerating battery drain. It is visible in the F5 panel as a zone past the 100% mark.
+
+### Subsystem Grouping
+
+- **Weapons** (group 0): Phasers, torpedoes, and pulse weapons are all set to the same percentage simultaneously
+- **Engines** (group 1): Impulse and warp engines are set together
+- **Sensors** (group 2): Standalone
+- **Shields** (group 3): Standalone
+
+### On/Off Boundary Behavior
+
+When the power percentage reaches boundaries, the subsystem's on/off state changes:
+
+- **Setting to 0%**: The subsystem is turned off. This fires a `SubsystemStatus` network message (immediate reliable delivery), so all peers are notified instantly.
+- **Setting to >0% on a disabled subsystem**: The subsystem is turned back on. Again fires an immediate `SubsystemStatus` message.
+- **Setting between 0% and 125% on an already-enabled subsystem**: No on/off change, power percentage propagates via the periodic state replication (not immediately).
+
+---
+
 ## Python API Surface
 
 ### Power Subsystem (reactor/battery manager)
@@ -460,6 +529,128 @@ auto-balancing steps.
 The design rationale: discrete toggles (on/off, LOW/MED/HIGH, torpedo type) use immediate
 reliable messages. Continuous values (power percentages) use the existing state replication,
 which is more bandwidth-efficient for frequently-changing values.
+
+---
+
+## Power State Wire Format
+
+This section describes the exact wire encoding and update algorithm for power state replication, providing the detail needed for a server to match client expectations.
+
+### Two Serialization Interfaces
+
+Power state uses two distinct serialization interfaces depending on context:
+
+#### Interface A: Round-Robin (StateUpdate flag 0x20)
+
+Used during **ongoing gameplay** in the subsystem health round-robin. Each powered subsystem conditionally includes a power byte:
+
+**Sender:**
+```
+[condition: byte]            // subsystem health: (currentHP / maxHP) * 255, truncated
+[children: recursive]        // each child subsystem writes its own condition byte
+[hasData: 1 bit]             // 1 = remote ship (include power), 0 = own ship (skip)
+[if hasData=1:]
+  [powerPctWanted: byte]     // (int)(powerPercentageWanted * 100.0), range 0-125
+```
+
+**Receiver:**
+```
+read condition byte + children (recursive)
+hasData = read 1 bit
+if hasData:
+    pctByte = read byte
+    if previousTimestamp < packetTimestamp:
+        SetPowerPercentageWanted(pctByte * 0.01)
+```
+
+The `hasData` bit allows the sender to skip power data when the recipient owns the ship, preventing stale server data from overwriting the player's local slider settings.
+
+#### Interface B: ObjCreate / Full Snapshot
+
+Used during **initial object creation** (ObjCreate opcode) and weapon round-robin. This path uses sign-bit encoding to pack the on/off state into the power byte:
+
+**Sender:**
+```
+[condition: byte]            // health
+[children: recursive]
+[powerByte: signed byte]     // positive = ON, negative = OFF
+                             // absolute value = (int)(powerPercentageWanted * 100.0)
+```
+
+**Receiver:**
+```
+read condition byte + children
+powerByte = read signed byte
+if powerByte < 1:            // 0 or negative
+    isOn = false
+    powerPercentageWanted = (-powerByte) * 0.01
+else:
+    isOn = true
+    powerPercentageWanted = powerByte * 0.01
+```
+
+**Sign-bit encoding rationale**: During ObjCreate, the receiver needs both the power percentage AND the on/off state. Packing them into one byte avoids an extra bit/byte for the toggle. A subsystem at 50% and OFF encodes as `-50`; the receiver restores both the slider position (50%) and the disabled state. This allows a player's pre-disable slider position to survive across the network.
+
+### Round-Robin Algorithm
+
+The subsystem health round-robin uses a **persistent cursor** per peer per ship, allowing it to resume where it left off each tick:
+
+1. **Per-peer state**: The server maintains a cursor (linked list node pointer) and an index counter for each ship being sent to each peer. These persist across ticks.
+2. **Start index**: Each flag 0x20 block begins with a `startIndex` byte telling the receiver which subsystem index the data starts from.
+3. **10-byte budget**: The serializer writes subsystem data until either 10 bytes of stream space are consumed, or the cursor wraps back to its starting position (full cycle complete).
+4. **Wrap detection**: When the cursor reaches the end of the subsystem linked list, it wraps to the beginning and resets the index to 0. If it reaches its starting position, the full cycle is complete and it stops.
+
+```
+[startIndex: byte]           // which subsystem index the round-robin starts from
+[subsystem_0: WriteState]    // subsystem at startIndex position
+[subsystem_1: WriteState]    // next subsystem (if budget allows)
+...                          // continues until 10-byte budget exhausted or full wrap
+```
+
+### Power Byte Encoding
+
+| Direction | Formula | Range | Precision |
+|-----------|---------|-------|-----------|
+| Send | `(int)(powerPercentageWanted * 100.0)` | 0–125 | Truncation toward zero |
+| Receive | `(float)byte * 0.01` | 0.00–1.25 | 1% steps |
+
+Maximum precision loss: 0.009 (e.g., 0.256 → byte 25 → 0.25).
+
+### Own-Ship Skip
+
+When sending state about ship X to the player who owns ship X:
+
+- **hasData = 0** (Interface A): Power byte is omitted. The client's local slider state is authoritative for its own ship.
+- **Interface B** (ObjCreate): Always includes power data, including for own ship.
+
+**Own-ship determination**: The sender compares the ship's object ID against the target peer's assigned ship object ID. If they match (and it's a multiplayer game), the ship is "own-ship" for that peer.
+
+**Server MUST implement this**: If the server sends power data (hasData=1) to the ship's owner, the server will continuously overwrite the player's local engineering slider positions with stale data, making the F5 panel unusable.
+
+### Timestamp Ordering
+
+The receiver only applies power data from Interface A if the packet timestamp is newer than the last known update timestamp. This prevents stale data from overwriting newer state in cases of packet reordering. The receiver saves the previous timestamp BEFORE processing the base class data (which updates the stored timestamp), then compares the incoming packet timestamp against the saved value.
+
+### Update Timing
+
+- **StateUpdate rate**: ~10Hz per ship (one StateUpdate packet every ~100ms)
+- **Per-tick budget**: 10 bytes for flag 0x20 (subsystem health)
+- **Sovereign example**: 11 top-level subsystems, variable bytes per subsystem (1–11 bytes depending on children and power data). Full cycle takes ~3-5 ticks.
+- **Full cycle time**: ~0.3–0.5 seconds at 10Hz for all subsystem power percentages to transmit
+- **Server must send StateUpdates at this rate** for clients to see smooth power bar updates on remote ships
+
+### Server Implementation Requirements
+
+For an OpenBC server to correctly replicate power state:
+
+1. **Track per-peer write cursor**: Maintain a subsystem list node pointer and index counter for each ship being sent to each peer. Persist across ticks.
+2. **Respect 10-byte budget**: Stop writing subsystem data when 10 bytes of stream space are consumed in the flag 0x20 block.
+3. **Send startIndex byte**: Write the current index counter at the start of each flag 0x20 block so the receiver knows which subsystem the data starts from.
+4. **Skip power data for own-ship**: When sending to the peer who owns the ship, set `hasData = 0` (omit power byte). This is critical — failing to do this makes the F5 panel unresponsive.
+5. **Include power data for remote ships**: For all other peers, set `hasData = 1` and encode power as `(int)(powerPercentageWanted * 100.0)`.
+6. **Use sign-bit encoding on ObjCreate**: When sending initial object state, pack on/off into the power byte (positive = ON, negative = OFF). This gives the client both the slider position and the subsystem's enable state.
+7. **Apply received power only if timestamp is newer**: When receiving power state from clients, compare the packet timestamp against the saved previous timestamp. Only apply if newer.
+8. **Do NOT validate power values**: The stock server does not clamp or reject power percentages. A client sending 125% (or even higher via a mod) should be accepted as-is.
 
 ---
 

--- a/docs/pythonevent-wire-format.md
+++ b/docs/pythonevent-wire-format.md
@@ -1,0 +1,478 @@
+# PythonEvent Wire Format (Opcode 0x06)
+
+Wire format specification for Star Trek: Bridge Commander's primary event forwarding
+message, documented from network packet captures and the game's shipped Python
+scripting API.
+
+**Clean room statement**: This document describes observable multiplayer behavior and
+network traffic patterns. No binary addresses, memory offsets, or decompiled code are
+referenced.
+
+---
+
+## Overview
+
+Opcode 0x06 (PythonEvent) is a **polymorphic serialized-event transport**. The host
+broadcasts game events to all clients using this opcode. The payload after the opcode
+byte is a serialized event object. The **first 4 bytes** of the payload are a factory
+type ID that determines which event class follows — different event types carry
+different fields.
+
+This is the primary mechanism for synchronizing repair-list changes, explosion
+notifications, and forwarded script events in multiplayer.
+
+**Direction**: Host → All Clients (via "NoMe" routing group)
+**Reliability**: Sent reliably (ACK required)
+**Frequency**: ~251 per 15-minute 3-player combat session (~3,432 total in a 34-minute
+session — the most frequently sent game opcode)
+
+### Opcode 0x0D (PythonEvent2)
+
+Opcode 0x0D shares the same receiver logic and has identical wire format. Both opcodes
+are decoded identically; 0x0D provides an alternate event path.
+
+---
+
+## Message Structure
+
+```
+Offset  Size  Type    Field          Notes
+------  ----  ----    -----          -----
+0       1     u8      opcode         Always 0x06
+1       4     i32     factory_id     Event class type (determines remaining layout)
+5       4     i32     event_type     Event type constant (0x008000xx)
+9       4     i32     source_obj_id  Source object reference
+13      4     i32     dest_obj_id    Destination/related object reference
+[class-specific extension follows]
+```
+
+The first 17 bytes are common to all event classes (base event fields). The payload
+after byte 16 depends on `factory_id`.
+
+All multi-byte values are **little-endian**.
+
+---
+
+## Object Reference Encoding
+
+Object reference fields use a three-way encoding:
+
+| Wire Value | Meaning |
+|-----------|---------|
+| `0x00000000` | NULL (no object) |
+| `0xFFFFFFFF` | Sentinel (-1, "self" reference) |
+| Any other value | Network object ID |
+
+### Ship Object IDs
+
+Ship object IDs follow a player-based allocation: Player N base = `0x3FFFFFFF + (N * 0x40000)`.
+
+### Subsystem Object IDs
+
+Subsystems do **not** derive their IDs from the ship's base ID. Each subsystem receives
+a globally unique ID from a sequential auto-increment counter at construction time. The
+assignment order depends on the ship's subsystem creation sequence, which varies by ship
+class.
+
+This means:
+- Subsystem IDs are **not predictable** from the ship's ID alone
+- The only way to resolve a subsystem ID is via hash table lookup on the receiving end
+- All subsystem IDs are assigned before the ship enters the game, so they are stable
+  for the lifetime of that ship instance
+- When a ship is destroyed and respawned, its subsystems receive new IDs from the counter
+
+A server implementation must maintain a mapping of subsystem IDs to subsystem objects,
+populated when the ship's subsystem list is created during InitObject deserialization.
+
+---
+
+## Three Event Classes
+
+### 1. SubsystemEvent (factory_id = 0x00000101)
+
+The most common event in collision traffic. No extension fields beyond the base event —
+factory_id + event_type + two object references is the complete payload.
+
+```
+Offset  Size  Type    Field            Notes
+------  ----  ----    -----            -----
+0       1     u8      opcode           0x06
+1       4     i32     factory_id       0x00000101
+5       4     i32     event_type       See table below
+9       4     i32     source_obj_id    Damaged subsystem (subsystem's own object ID)
+13      4     i32     dest_obj_id      Repair subsystem that queued it (repair sub's object ID)
+```
+
+**Total**: 17 bytes (fixed).
+
+Both object references are **subsystem-level IDs**, not ship IDs. See "Subsystem Object
+IDs" above for how these are allocated.
+
+**Event types**:
+
+| Event Type | Name | Meaning |
+|-----------|------|---------|
+| `0x008000DF` | ADD_TO_REPAIR_LIST | Subsystem damaged, added to repair queue |
+| `0x00800074` | REPAIR_COMPLETED | Subsystem condition reached max (repair finished) |
+| `0x00800075` | REPAIR_CANNOT_BE_COMPLETED | Subsystem destroyed while in repair queue (condition reached 0.0) |
+
+### 2. CharEvent (factory_id = 0x00000105)
+
+Extends SubsystemEvent with a single byte payload. This class is primarily used by
+opcodes 0x07-0x12 and 0x1B (weapon, cloak, and warp events) rather than opcode 0x06.
+Documented here because the polymorphic deserializer handles any registered factory
+type.
+
+```
+Offset  Size  Type    Field            Notes
+------  ----  ----    -----            -----
+0       1     u8      opcode           0x06
+1       4     i32     factory_id       0x00000105
+5       4     i32     event_type       Depends on specific event
+9       4     i32     source_obj_id    Source object
+13      4     i32     dest_obj_id      Related object
+17      1     u8      char_value       Single-byte payload
+```
+
+**Total**: 18 bytes (fixed).
+
+See [set-phaser-level-wire-format.md](set-phaser-level-wire-format.md) for detailed
+analysis of CharEvent usage.
+
+### Class Hierarchy
+
+```
+Event (base, factory 0x02)
+  └── SubsystemEvent (factory 0x101)
+        └── CharEvent (factory 0x105)
+```
+
+The `IsA` check reports true for all IDs in the ancestry chain.
+
+### 3. ObjectExplodingEvent (factory_id = 0x00008129)
+
+Carries ship destruction notifications. Extends the base event with a firing player
+ID (who killed the ship) and an explosion lifetime (visual effect duration).
+
+```
+Offset  Size  Type    Field              Notes
+------  ----  ----    -----              -----
+0       1     u8      opcode             0x06
+1       4     i32     factory_id         0x00008129
+5       4     i32     event_type         Always 0x0080004E (OBJECT_EXPLODING)
+9       4     i32     source_obj_id      Object that is exploding
+13      4     i32     dest_obj_id        Target (typically NULL or sentinel)
+17      4     i32     firing_player_id   Connection ID of the killer
+21      4     f32     lifetime           Explosion effect duration (seconds)
+```
+
+**Total**: 25 bytes (fixed).
+
+---
+
+## Three Producers
+
+Not all PythonEvent messages come from the same source. The game has three distinct
+event-to-network pathways:
+
+### 1. Host Event Handler
+
+**Registered for**: ADD_TO_REPAIR_LIST, REPAIR_COMPLETED, REPAIR_CANNOT_BE_COMPLETED
+
+This is the collision damage pathway. When a subsystem is damaged and added to the
+repair queue, the handler serializes the event and sends it reliably to the "NoMe"
+routing group (all peers except the host itself).
+
+**Gate condition**: Only registered when multiplayer is active.
+
+**Event generation chain**:
+1. Subsystem condition decreases below maximum → posts SUBSYSTEM_HIT (internal only)
+2. Repair subsystem catches SUBSYSTEM_HIT, adds to repair queue (rejects duplicates)
+3. If add succeeded AND host AND multiplayer → posts ADD_TO_REPAIR_LIST
+4. Host Event Handler catches ADD_TO_REPAIR_LIST → serializes as opcode 0x06
+
+### 2. Object Exploding Handler
+
+**Registered for**: OBJECT_EXPLODING (0x0080004E)
+
+When a ship is destroyed, this handler serializes the explosion event and sends it
+reliably to the "NoMe" group. In single-player, it directly triggers the explosion
+visual effect instead.
+
+**Gate condition**: Always registered, but internally checks multiplayer flag. In
+multiplayer: serialize + send. In single-player: apply locally.
+
+### 3. Generic Event Forward (NOT opcode 0x06)
+
+Used by many other handlers (StartFiring, StopFiring, SubsystemStatus, StartCloak,
+etc.) that forward events over the network. This pathway writes the **specific opcode**
+for each event type (0x07, 0x08, 0x0A, etc.), **NOT** 0x06. Included here only to
+clarify that it is NOT a source of PythonEvent messages despite sharing the same
+serialization mechanism.
+
+---
+
+## Receiver Behavior
+
+### Opcode 0x06 / 0x0D Receiver
+
+When a client receives a PythonEvent:
+
+1. **Skip** the opcode byte (0x06)
+2. **Read** the factory type ID (first 4 bytes of payload)
+3. **Construct** the correct event class using the factory registry
+4. **Deserialize** remaining fields via the class-specific reader
+5. **Resolve** object references (network IDs → local objects)
+6. **Dispatch** the event through the local event system
+
+Local event handlers then process the event — for example, updating the repair queue
+UI, playing explosion sound effects, or triggering visual feedback.
+
+**No relay**: The opcode 0x06 receiver does NOT relay the message. It only deserializes
+and dispatches locally. PythonEvents originate on the host and are sent directly to
+clients — no further forwarding is needed.
+
+### Client-to-Host Path (rare)
+
+If a client sends an opcode 0x06 message to the host (script-initiated events), the
+host will:
+1. Relay the message to all other connected clients (excluding sender)
+2. Also process the event locally
+
+This relay path ensures all peers see script events regardless of origin.
+
+### Opcodes 0x07-0x12, 0x1B (Generic Event Forward)
+
+These opcodes use a **different receiver** that performs both relay and dispatch. The
+receiver applies an event type override after deserialization — implementing the
+sender/receiver event code pairing system.
+
+#### Event Type Override Table
+
+| Opcode | Name | Sender Code | Receiver Override |
+|--------|------|-------------|-------------------|
+| 0x07 | StartFiring | 0x008000D8 | 0x008000D7 |
+| 0x08 | StopFiring | 0x008000DA | 0x008000D9 |
+| 0x09 | StopFiringAtTarget | 0x008000DC | 0x008000DB |
+| 0x0A | SubsystemStatusChanged | 0x0080006C | 0x0080006C (no change) |
+| 0x0B | AddToRepairList | 0x008000DF | Preserve original |
+| 0x0C | ClientEvent | (varies) | Preserve original |
+| 0x0E | StartCloaking | 0x008000E2 | 0x008000E3 |
+| 0x0F | StopCloaking | 0x008000E4 | 0x008000E5 |
+| 0x10 | StartWarp | 0x008000EC | 0x008000ED |
+| 0x11 | RepairListPriority | 0x00800076 | Preserve original |
+| 0x12 | SetPhaserLevel | 0x008000E0 | Preserve original |
+| 0x1B | TorpedoTypeChange | 0x008000FE | 0x008000FD |
+
+"Preserve original" means the event arrives with its wire event code unchanged. Opcodes
+with an override replace the event code after deserialization — this implements
+sender/receiver asymmetry (e.g., a sender locally posts "start firing notify" but
+receivers post "start firing command").
+
+---
+
+## Collision Damage → PythonEvent Chain
+
+When two ships collide in multiplayer, the host generates approximately **14 PythonEvent
+(opcode 0x06) messages**:
+
+```
+Collision Detection
+    │
+    ▼
+Host Validates Collision (ownership, proximity, dedup)
+    │
+    ▼
+Per-Contact Damage Application
+    │
+    ▼
+Per-Subsystem Condition Update (SetCondition)
+    │
+    ├──→ Posts SUBSYSTEM_HIT event (internal)
+    │        │
+    │        ▼
+    │    Repair Subsystem catches SUBSYSTEM_HIT
+    │        │
+    │        ▼
+    │    Adds subsystem to repair queue (rejects duplicates)
+    │        │
+    │        ▼
+    │    Posts ADD_TO_REPAIR_LIST [host + MP only]
+    │        │
+    │        ▼
+    │    Host Event Handler serializes as PythonEvent (0x06)
+    │        │
+    │        ▼
+    │    Sent reliably to "NoMe" group
+    │
+    ▼
+(next subsystem...)
+```
+
+### Why ~14 Messages
+
+- Two ships collide → each takes damage
+- Each ship has ~7 top-level subsystems in the damage volume (shields, hull sections,
+  weapons, etc.)
+- Each damaged subsystem → one ADD_TO_REPAIR_LIST → one PythonEvent
+- 7 subsystems × 2 ships = ~14 PythonEvent messages
+
+The exact count varies with collision geometry and whether subsystems are already in the
+repair queue (duplicates are rejected).
+
+### Key Behavioral Invariant
+
+ADD_TO_REPAIR_LIST is ONLY posted when **all three conditions** are true:
+- The subsystem was successfully added to the queue (not a duplicate)
+- The game is running as host
+- Multiplayer is active
+
+This prevents clients from generating spurious repair events and ensures only the host's
+authoritative damage decisions produce network traffic.
+
+---
+
+## Decoded Packet Examples
+
+### Example 1: ADD_TO_REPAIR_LIST (17 bytes)
+
+```
+06                    opcode = 0x06 (PythonEvent)
+01 01 00 00           factory_id = 0x00000101 (SubsystemEvent)
+DF 00 80 00           event_type = 0x008000DF (ADD_TO_REPAIR_LIST)
+2A 00 00 00           source_obj = 0x0000002A (damaged subsystem's object ID)
+1E 00 00 00           dest_obj = 0x0000001E (repair subsystem's object ID)
+```
+
+Note: subsystem object IDs are small sequential integers from the global counter, not
+player-base IDs like ship objects.
+
+### Example 2: OBJECT_EXPLODING (25 bytes)
+
+```
+06                    opcode = 0x06 (PythonEvent)
+29 81 00 00           factory_id = 0x00008129 (ObjectExplodingEvent)
+4E 00 80 00           event_type = 0x0080004E (OBJECT_EXPLODING)
+FF FF FF 3F           source_obj = 0x3FFFFFFF (Player 0's ship, exploding)
+FF FF FF FF           dest_obj = sentinel (-1)
+02 00 00 00           firing_player_id = 2 (killed by player 2)
+00 00 80 3F           lifetime = 1.0f (1 second explosion)
+```
+
+### Example 3: REPAIR_COMPLETED (17 bytes)
+
+```
+06                    opcode = 0x06 (PythonEvent)
+01 01 00 00           factory_id = 0x00000101 (SubsystemEvent)
+74 00 80 00           event_type = 0x00800074 (REPAIR_COMPLETED)
+2A 00 00 00           source_obj = 0x0000002A (repaired subsystem's object ID)
+1E 00 00 00           dest_obj = 0x0000001E (repair subsystem's object ID)
+```
+
+---
+
+## Traffic Statistics (15-minute 3-player session)
+
+| Direction | Count | Notes |
+|-----------|-------|-------|
+| PythonEvent S→C | ~251 | Repair list + explosions + script events |
+| PythonEvent C→S | 0 | Clients never send 0x06 in the collision path |
+| CollisionEffect C→S | ~84 | Client collision reports (opcode 0x15) |
+
+All collision-path PythonEvents are **host-generated, server-to-client only**.
+
+---
+
+## Required Event Registrations
+
+For the collision → PythonEvent chain to function, three registration levels must be active:
+
+### 1. Repair Subsystem Per-Instance Registration
+
+Each ship's repair subsystem must register handlers during its initialization:
+- SUBSYSTEM_HIT → adds damaged subsystem to repair queue
+- REPAIR_COMPLETED → cleanup
+- SUBSYSTEM_DAMAGED → tracks damage state
+- REPAIR_CANCELLED → cleanup
+
+Registered per ship instance (not globally). **Not gated on multiplayer** — always
+registered.
+
+### 2. Multiplayer Game Host Event Handler Registration
+
+The multiplayer game object registers during construction:
+- ADD_TO_REPAIR_LIST → serializes as opcode 0x06
+- REPAIR_COMPLETED → serializes as opcode 0x06
+- REPAIR_CANCELLED → serializes as opcode 0x06
+- OBJECT_EXPLODING → serializes as opcode 0x06
+
+**Gated on multiplayer mode** — only registered when a multiplayer game is active.
+
+### 3. Ship Class Static Registration
+
+Global (class-level) registration for collision processing:
+- COLLISION_EFFECT → collision validation + damage application
+- HOST_COLLISION_EFFECT → same, for client-reported collisions
+
+Registered during class initialization (not per-instance).
+
+If any registration level is missing, the chain breaks silently — damage may still
+apply, but no PythonEvent messages are generated, and clients see no repair queue
+updates.
+
+---
+
+## Server Implementation Notes
+
+### Minimal Server (hull damage only)
+
+A server that only tracks hull HP (no repair queue) can skip PythonEvent generation
+entirely. Collision damage still applies through the damage pipeline; PythonEvent
+messages only carry repair-queue notifications and explosion effects.
+
+### Full Server (subsystem repair + explosions)
+
+For a full implementation:
+
+1. **Repair events**: When applying collision damage to a subsystem:
+   a. Check if condition decreased below maximum
+   b. If so, add to the ship's repair queue (reject duplicates)
+   c. If the add succeeds and this is the host in multiplayer:
+      - Serialize a SubsystemEvent (factory 0x101) with event type ADD_TO_REPAIR_LIST
+      - Send reliably to all other peers via the "NoMe" routing group
+
+2. **Explosion events**: When a ship is destroyed:
+   a. Serialize an ObjectExplodingEvent (factory 0x8129) with the killer's player ID
+      and explosion duration
+   b. Send reliably to all other peers via "NoMe"
+
+3. **Repair completion/cancellation**: When repair finishes or is cancelled:
+   - Same pattern as repair events with the appropriate event type
+
+### Serialization Pattern (all producers)
+
+All three producers use the same message construction:
+1. Write opcode byte `0x06`
+2. Serialize the event object (factory_id + event_type + object refs + class extensions)
+3. Wrap in a reliable message
+4. Send to "NoMe" routing group
+
+### Client Relay
+
+If a client sends an opcode 0x06 to the host (script events), the host should:
+1. Forward to all other peers (excluding sender)
+2. Process locally
+
+---
+
+## Related Documents
+
+- **[collision-damage-event-chain.md](collision-damage-event-chain.md)** — Complete collision → PythonEvent chain
+- **[collision-effect-wire-format.md](collision-effect-wire-format.md)** — Opcode 0x15 (client collision reports)
+- **[collision-detection-system.md](collision-detection-system.md)** — 3-tier collision detection pipeline
+- **[set-phaser-level-wire-format.md](set-phaser-level-wire-format.md)** — CharEvent (0x105) detailed analysis
+- **[explosion-wire-format.md](explosion-wire-format.md)** — Opcode 0x29 (Explosion damage)
+- **[combat-system.md](combat-system.md)** — Full damage pipeline, shields, subsystem distribution
+- **[ship-subsystems.md](ship-subsystems.md)** — Subsystem index table and HP values
+- **[server-authority.md](server-authority.md)** — Authority model (collision damage is host-authoritative)
+- **[stateupdate-wire-format.md](stateupdate-wire-format.md)** — Subsystem health in StateUpdate flag 0x20

--- a/docs/repair-system.md
+++ b/docs/repair-system.md
@@ -1,0 +1,330 @@
+# Repair System — Behavioral Specification
+
+How Bridge Commander's repair system works: queue management, repair rate formula, priority toggling, wire formats, and Engineering panel behavior. This document describes observable behavior and game script values only.
+
+**Clean room statement**: This document describes repair system mechanics as observable in-game behavior, readable game scripts, and wire protocol analysis. No binary addresses, memory offsets, or decompiled code are referenced.
+
+---
+
+## Overview
+
+Each ship has a single repair subsystem that manages a queue of damaged subsystems. The repair system continuously repairs subsystems from the front of the queue, with multiple repair teams working simultaneously. Players interact via the Engineering panel to prioritize which subsystems are repaired first.
+
+---
+
+## 1. Repair Queue
+
+### Data Structure
+
+The repair queue is a **doubly-linked list** with no fixed maximum size. It grows dynamically as subsystems are damaged.
+
+### Queue Operations
+
+| Operation | Behavior |
+|-----------|----------|
+| **Add** | New subsystems are inserted at the **tail** of the queue |
+| **Remove** | Subsystems are removed when fully repaired, destroyed, or manually removed |
+| **Duplicate check** | The queue is walked before adding; duplicates are silently rejected |
+| **Destroyed exclusion** | Subsystems with 0 HP are NOT added to the queue; instead, the UI is notified to display them as "destroyed" |
+
+### Logical Partitions
+
+The queue has two logical zones determined by `num_repair_teams`:
+
+| Zone | Positions | Status |
+|------|-----------|--------|
+| **Active** | First `num_repair_teams` items from head | Being actively repaired |
+| **Waiting** | Remaining items after active zone | Queued but not yet receiving repair |
+
+---
+
+## 2. Repair Rate Formula
+
+```
+raw_repair = max_repair_points * repair_system_health_pct * dt
+
+divisor = min(queue_count, num_repair_teams)
+
+per_subsystem = raw_repair / divisor
+
+condition_gain = per_subsystem / subsystem_repair_complexity
+```
+
+### Key Characteristics
+
+1. **Repair system health scales output**: A damaged repair bay repairs slower. At 50% health, repair output is halved.
+2. **Multiple subsystems repaired simultaneously**: Up to `num_repair_teams` subsystems are repaired each tick.
+3. **Equal division**: The raw repair amount is split equally among all active repair slots (`min(queue_count, num_repair_teams)`).
+4. **RepairComplexity divisor**: Each subsystem has a complexity value that further reduces repair speed. Higher complexity = slower repair.
+5. **Destroyed subsystems are skipped**: If a queued subsystem reaches 0 HP, it is not repaired. Instead, a "cannot be completed" notification is sent. It does NOT consume a repair team slot.
+
+### Example (Sovereign class, healthy repair system, 2 items queued)
+
+```
+raw_repair = 50.0 * 1.0 * 0.033 = 1.65 per tick (at 30fps)
+divisor = min(2, 3) = 2
+per_subsystem = 1.65 / 2 = 0.825
+
+For a sensor (complexity=1.0): condition_gain = 0.825 / 1.0 = 0.825 HP/tick
+For a phaser (complexity=3.0): condition_gain = 0.825 / 3.0 = 0.275 HP/tick
+For a tractor (complexity=7.0): condition_gain = 0.825 / 7.0 = 0.118 HP/tick
+```
+
+---
+
+## 3. Priority Toggle Algorithm
+
+When a player clicks a subsystem in the Engineering repair panel, a priority toggle occurs:
+
+| Current Position | Action |
+|-----------------|--------|
+| **Active zone** (being repaired) | **Demote**: Remove from current position, re-insert at **tail** |
+| **Waiting zone** (not being repaired) | **Promote**: Remove from current position, re-insert at **head** |
+
+This is a **binary toggle** — there is no "move up one position" or gradual reordering. Clicking always jumps to the front or the back.
+
+### "Being Repaired" Check
+
+A subsystem is considered "being repaired" if it appears within the first `num_repair_teams` positions from the queue head. The check walks forward from head, counting up to `num_repair_teams` nodes.
+
+---
+
+## 4. Queue Auto-Management
+
+### Auto-Add on Damage
+
+When a subsystem takes damage (its condition drops below max_condition), the repair system automatically adds it to the queue:
+
+1. Damage event fires (subsystem_hit)
+2. Repair subsystem catches the event
+3. Calls add-to-queue with duplicate rejection
+4. If added AND this is the host in multiplayer: broadcasts notification to all clients
+
+### Auto-Remove on Full Repair
+
+During the repair tick, when a subsystem's condition reaches max_condition:
+
+1. A "repair completed" event is posted
+2. The handler removes the subsystem from the queue
+3. UI is refreshed
+
+### Destroyed Subsystem Handling
+
+If a subsystem reaches 0 HP while in the repair queue:
+
+1. During the repair tick, the destroyed subsystem is detected (condition <= 0)
+2. A "repair cannot be completed" event is posted
+3. The handler removes the subsystem from the queue
+4. UI moves the item to the "destroyed" display area (vs just removing it)
+
+### Rebuilt Subsystem Re-Queue
+
+When a destroyed subsystem is rebuilt (e.g. via script command):
+
+1. A "subsystem rebuilt" event fires
+2. The handler checks if condition < max_condition
+3. If so, re-queues the subsystem for continued repair
+
+---
+
+## 5. Engineering Panel UI
+
+### Three Display Areas
+
+| Area | Content | Click Action |
+|------|---------|-------------|
+| **Repair Area** | Subsystems being actively repaired (first `num_repair_teams`) | Click → demote to tail |
+| **Waiting Area** | Queued but waiting for a free repair team | Click → promote to head |
+| **Destroyed Area** | Subsystems at 0 HP | No action |
+
+### Player Ship Tracking
+
+The Engineering panel tracks whichever ship the local player controls. When the player's ship changes (e.g. spectator mode, game start), the panel:
+
+1. Clears all displayed items
+2. Points to the new ship's repair subsystem
+3. Sets the number of active repair slots from the new ship's `num_repair_teams`
+
+---
+
+## 6. Wire Protocol
+
+### Three Network Paths
+
+Repair events use three distinct opcodes depending on direction and purpose:
+
+#### Path 1: PythonEvent (opcode 0x06) — Host Auto-Notifications
+
+**Direction**: Host → All Clients (reliable)
+
+The host generates these automatically during the repair tick. They use the `SubsystemEvent` serialization (factory type `0x0101`).
+
+| Event | Meaning |
+|-------|---------|
+| ADD_TO_REPAIR_LIST | Subsystem was damaged and added to repair queue |
+| REPAIR_COMPLETED | Subsystem reached max HP, removed from queue |
+| REPAIR_CANNOT_BE_COMPLETED | Subsystem destroyed while in queue |
+
+**Wire format** (17 bytes fixed):
+```
+Offset  Size  Type    Field            Notes
+------  ----  ----    -----            -----
+0       1     u8      opcode           0x06
+1       4     i32     factory_id       0x00000101
+5       4     i32     event_type       Event constant (see table above)
+9       4     i32     source_obj_id    Damaged subsystem's network object ID
+13      4     i32     dest_obj_id      Repair subsystem's network object ID
+```
+
+Both source and dest contain **subsystem-level object IDs** (globally unique, auto-assigned at construction), NOT ship IDs. These are resolved on the receiving end via the global object hash table.
+
+#### Path 2: AddToRepairList (opcode 0x0B) — Client Manual Repair Request
+
+**Direction**: Client → Host → All (relayed via GenericEventForward)
+**Event type**: preserved (no override)
+
+Sent when a player manually requests repair of a subsystem. Uses `CharEvent` serialization (factory type `0x0105`).
+
+**Wire format** (18 bytes fixed):
+```
+Offset  Size  Type    Field            Notes
+------  ----  ----    -----            -----
+0       1     u8      opcode           0x0B
+1       4     i32     factory_id       0x00000105
+5       4     i32     event_type       ADD_TO_REPAIR_LIST
+9       4     i32     source_obj_id    Source object
+13      4     i32     dest_obj_id      Related object
+17      1     u8      char_value       Extra data
+```
+
+#### Path 3: RepairListPriority (opcode 0x11) — Client Priority Toggle
+
+**Direction**: Client → Host → All (relayed via GenericEventForward)
+**Event type**: REPAIR_INCREASE_PRIORITY (preserved, no override)
+
+Sent when a player clicks a subsystem in the repair queue to change its priority.
+
+**Wire format** (18 bytes fixed):
+```
+Offset  Size  Type    Field            Notes
+------  ----  ----    -----            -----
+0       1     u8      opcode           0x11
+1       4     i32     factory_id       0x00000105
+5       4     i32     event_type       REPAIR_INCREASE_PRIORITY
+9       4     i32     source_obj_id    Source object
+13      4     i32     dest_obj_id      Related object
+17      1     u8      char_value       Subsystem ID
+```
+
+### GenericEventForward Relay Pattern
+
+Opcodes 0x0B and 0x11 use the same relay mechanism as other GenericEventForward opcodes (0x07-0x12, 0x1B):
+
+1. Client sends to host
+2. Host removes sender from "Forward" group temporarily
+3. Host forwards message to remaining group members
+4. Host re-adds sender
+5. Host deserializes and dispatches locally
+
+Both opcodes have event type override = 0 (preserve original), meaning the event type from the wire is used directly on the receiving end.
+
+### Singleplayer Gate
+
+The local `HandleAddToRepairList` handler has a multiplayer gate — it **only runs in singleplayer**. In multiplayer, the opcode 0x0B network path handles repair list additions instead. This prevents double-processing.
+
+---
+
+## 7. Event Types
+
+| Event | Direction | Trigger |
+|-------|-----------|---------|
+| ADD_TO_REPAIR_LIST | Host → All (opcode 0x06) | Subsystem damaged and auto-queued |
+| REPAIR_COMPLETED | Host → All (opcode 0x06) | Subsystem reached max HP |
+| REPAIR_CANNOT_BE_COMPLETED | Host → All (opcode 0x06) | Subsystem destroyed while queued |
+| REPAIR_INCREASE_PRIORITY | Client → Host (opcode 0x11) | Player clicked priority toggle |
+| SUBSYSTEM_HIT | Internal only | Damage triggers auto-add to queue |
+| SUBSYSTEM_DAMAGED | Internal only | General damage tracking |
+| SET_PLAYER | Internal only | Player's ship changed, reconfigure UI |
+
+---
+
+## 8. Collision → Repair Chain
+
+When two ships collide, the following chain generates approximately **14 repair queue events**:
+
+1. Collision detected → collision damage applied to both ships
+2. Each damaged subsystem's condition drops below max → SUBSYSTEM_HIT event fires
+3. Repair subsystem catches SUBSYSTEM_HIT → adds subsystem to queue (rejects duplicates)
+4. If add succeeds on host: posts ADD_TO_REPAIR_LIST event
+5. HostEventHandler serializes as opcode 0x06 → sends reliably to all clients
+6. Each client deserializes, resolves object IDs via hash table, adds to local queue
+
+**Per collision**: ~7 subsystems per ship x 2 ships = ~14 PythonEvent messages. Exact count varies with collision geometry and duplicate rejection.
+
+---
+
+## 9. Server Implementation Notes
+
+### Host-Only Repair Processing
+
+The repair tick (Update function) is **gated on host or standalone**:
+- Standalone (not multiplayer): always processes repairs
+- Multiplayer host: processes repairs
+- Multiplayer client: does NOT process repairs (relies on host notifications)
+
+### Event Broadcasting
+
+The host broadcasts three event types via HostEventHandler (opcode 0x06):
+- ADD_TO_REPAIR_LIST — so clients update their local queues
+- REPAIR_COMPLETED — so clients remove completed items
+- REPAIR_CANNOT_BE_COMPLETED — so clients show destroyed indicators
+
+All three are sent reliably (ACK required).
+
+### Object ID Resolution
+
+Repair events reference subsystems by their globally unique network object IDs. These are NOT derived from ship IDs — they are sequential values assigned at construction time from a global auto-increment counter. The receiving end resolves IDs via a global hash table lookup.
+
+A server implementation must:
+1. Assign unique object IDs to every subsystem at ship creation time
+2. Maintain a lookup table mapping ID → subsystem object
+3. Use these IDs in all repair-related events
+
+---
+
+## 10. Ship Reference Values
+
+### Sovereign-Class Repair Properties
+
+| Property | Value |
+|----------|-------|
+| MaxRepairPoints | 50.0 |
+| NumRepairTeams | 3 |
+| Repair MaxCondition | 8,000 |
+| Repair RepairComplexity | 1.0 |
+
+### Subsystem RepairComplexity Values
+
+| Subsystem | RepairComplexity | Effect |
+|-----------|-----------------|--------|
+| Sensor Array | 1.0 | Fastest repair (no divisor penalty) |
+| Repair System | 1.0 | Fastest |
+| Warp Core | 2.0 | 2x slower than complexity 1.0 |
+| Hull | 3.0 | 3x slower |
+| Impulse Engines | 3.0 | 3x slower |
+| Bridge | 4.0 | 4x slower |
+| Tractor System | 7.0 | Slowest (7x penalty) |
+| Tractor Projector | 7.0 | Slowest |
+
+Higher RepairComplexity = proportionally slower repair for that subsystem. The complexity value acts as a direct divisor on the repair points received.
+
+---
+
+## Related Documents
+
+- [combat-system.md](combat-system.md) — Consolidated combat system spec (shields, weapons, cloak, tractor, repair summary)
+- [collision-damage-event-chain.md](collision-damage-event-chain.md) — Collision → damage → repair event chain
+- [collision-shield-interaction.md](collision-shield-interaction.md) — Shield absorption during collisions
+- [pythonevent-wire-format.md](pythonevent-wire-format.md) — PythonEvent (opcode 0x06) polymorphic transport
+- [set-phaser-level-wire-format.md](set-phaser-level-wire-format.md) — GenericEventForward pattern reference
+- [ship-subsystems.md](ship-subsystems.md) — Full subsystem catalog with HP and properties

--- a/include/openbc/combat.h
+++ b/include/openbc/combat.h
@@ -76,20 +76,24 @@ int bc_combat_find_hit_subsystems(const bc_ship_class_t *cls,
  * impact_dir = normalized direction from attacker to target.
  * area_effect: true = damage/6 per shield facing, false = single facing.
  * damage_radius: used for subsystem AABB overlap test (scaled by target's
- * damage_radius_multiplier; if multiplier is 0.0, subsystem damage skipped). */
+ * damage_radius_multiplier; if multiplier is 0.0, subsystem damage skipped).
+ * shield_scale: multiplier on shield absorption capacity (1.0 = normal,
+ * 1.5 = collision shields absorb 50% more before overflow). */
 void bc_combat_apply_damage(bc_ship_state_t *target,
                             const bc_ship_class_t *cls,
                             f32 damage, f32 damage_radius,
                             bc_vec3_t impact_dir,
-                            bool area_effect);
+                            bool area_effect,
+                            f32 shield_scale);
 
-/* Compute collision damage from raw collision energy.
- * raw = (energy / mass) / contact_count
- * scaled = raw * scale + offset
- * Returns min(scaled, 0.5). */
-f32 bc_combat_collision_damage(f32 collision_energy, f32 ship_mass,
-                               int contact_count,
-                               f32 collision_scale, f32 collision_offset);
+/* Path 1 — Direct collision: raw * 0.1 + 0.1, cap 0.5 (fractional). */
+f32 bc_combat_collision_damage_path1(f32 collision_energy, f32 ship_mass,
+                                      int contact_count);
+
+/* Path 2 — Collision effect handler: raw * 900 + 500 (absolute HP).
+ * Dead zone at raw <= 0.01. Used by server collision handler. */
+f32 bc_combat_collision_damage_path2(f32 collision_energy, f32 ship_mass,
+                                      int contact_count);
 
 /* --- Shield recharge --- */
 

--- a/include/openbc/game_builders.h
+++ b/include/openbc/game_builders.h
@@ -94,6 +94,33 @@ int bc_build_score_change(u8 *buf, int buf_size,
 #define BC_END_REASON_SCORE_LIMIT   3
 int bc_build_end_game(u8 *buf, int buf_size, i32 reason);
 
+/* --- PythonEvent (0x06) builders --- */
+
+/* PythonEvent factory IDs */
+#define BC_FACTORY_SUBSYSTEM_EVENT  0x00000101
+#define BC_FACTORY_OBJECT_EXPLODING 0x00008129
+
+/* PythonEvent type constants */
+#define BC_EVENT_ADD_TO_REPAIR      0x008000DF
+#define BC_EVENT_REPAIR_COMPLETED   0x00800074
+#define BC_EVENT_REPAIR_CANNOT      0x00800075
+#define BC_EVENT_OBJECT_EXPLODING   0x0080004E
+
+/* SubsystemEvent: [0x06][factory=0x101:i32][event_type:i32][source:i32][dest:i32]
+ * 17 bytes total. Used for ADD_TO_REPAIR_LIST, REPAIR_COMPLETED, etc. */
+int bc_build_python_subsystem_event(u8 *buf, int buf_size,
+                                     i32 event_type,
+                                     i32 source_obj_id,
+                                     i32 dest_obj_id);
+
+/* ObjectExplodingEvent: [0x06][factory=0x8129:i32][event_type=0x4E:i32]
+ *   [source:i32][dest=-1:i32][killer_id:i32][lifetime:f32]
+ * 25 bytes total. */
+int bc_build_python_exploding_event(u8 *buf, int buf_size,
+                                     i32 source_obj_id,
+                                     i32 firing_player_id,
+                                     f32 lifetime);
+
 /* --- Tier 2: Generic builders --- */
 
 /* StateUpdate: [0x1C][obj:i32][time:f32][dirty:u8][field_data...] */

--- a/include/openbc/server_dispatch.h
+++ b/include/openbc/server_dispatch.h
@@ -23,6 +23,10 @@ f32 bc_powered_efficiency(const bc_ship_state_t *ship,
                           const bc_ship_class_t *cls,
                           const char *child_type);
 
+/* Global auto-increment counter for subsystem object IDs (PythonEvent).
+ * Defined in server_dispatch.c, used by main.c for respawn. */
+extern i32 g_script_obj_counter;
+
 /* Torpedo callbacks for bc_torpedo_tick() -- defined in server_dispatch.c,
  * called from the main loop's simulation tick. */
 void bc_torpedo_hit_callback(int shooter_slot, i32 target_id,

--- a/include/openbc/ship_data.h
+++ b/include/openbc/ship_data.h
@@ -67,6 +67,11 @@ typedef struct {
 /* Serialization list entry: one top-level subsystem in the flag 0x20 round-robin.
  * Each entry has a format (Base/Powered/Power), an hp_index into subsystem_hp[],
  * and optionally children that are serialized recursively. */
+/* Power draw modes for powered subsystems */
+#define BC_POWER_MODE_MAIN_FIRST   0  /* Draw from main conduit, fallback to backup */
+#define BC_POWER_MODE_BACKUP_FIRST 1  /* Draw from backup conduit, fallback to main */
+#define BC_POWER_MODE_BACKUP_ONLY  2  /* Draw only from backup conduit */
+
 typedef struct {
     u8  format;                               /* BC_SS_FORMAT_BASE/POWERED/POWER */
     int hp_index;                             /* index into subsystem_hp[] */
@@ -75,6 +80,7 @@ typedef struct {
     int child_hp_index[BC_SS_MAX_CHILDREN];   /* children's indices into subsystem_hp[] */
     f32 child_max_condition[BC_SS_MAX_CHILDREN];
     f32 normal_power;                         /* power draw units/sec at 100% */
+    u8  power_mode;                           /* BC_POWER_MODE_* (0=main-first default) */
 } bc_ss_entry_t;
 
 /* Complete serialization list for a ship class. Determines wire format order
@@ -109,6 +115,7 @@ typedef struct {
     i32     num_repair_teams;
     f32     damage_radius_multiplier;  /* 1.0 = normal, 0.0 = immune */
     f32     damage_falloff_multiplier; /* 1.0 = normal */
+    f32     bounding_extent;           /* max distance from origin to any subsystem center */
     int     subsystem_count;
     bc_subsystem_def_t subsystems[BC_MAX_SUBSYSTEMS];
 

--- a/include/openbc/ship_state.h
+++ b/include/openbc/ship_state.h
@@ -56,7 +56,7 @@ typedef struct {
     i32        tractor_target_id; /* -1 = none */
 
     /* Power allocation (indexed by ser_list entry index) */
-    u8         power_pct[BC_SS_MAX_ENTRIES];     /* 0-100, Powered entries only */
+    u8         power_pct[BC_SS_MAX_ENTRIES];     /* 0-125, Powered entries only */
     bool       subsys_enabled[BC_SS_MAX_ENTRIES]; /* on/off state per entry */
     u8         phaser_level;                      /* 0=LOW, 1=MED, 2=HIGH */
 
@@ -74,6 +74,11 @@ typedef struct {
     bool       alive;
     u8         repair_queue[BC_MAX_SUBSYSTEMS];
     int        repair_count;
+
+    /* PythonEvent subsystem object IDs (sequential counter, NOT player-base IDs).
+     * Assigned by bc_ship_assign_subsystem_ids() after bc_ship_init(). */
+    i32        subsys_obj_id[BC_MAX_SUBSYSTEMS];
+    i32        repair_subsys_obj_id;  /* the repair subsystem's object ID (-1 if none) */
 } bc_ship_state_t;
 
 /* Initialize a ship state from registry class data.
@@ -84,6 +89,13 @@ void bc_ship_init(bc_ship_state_t *ship,
                   i32 object_id,
                   u8 owner_slot,
                   u8 team_id);
+
+/* Assign sequential object IDs to each subsystem in serialization list order.
+ * Must be called after bc_ship_init(). counter is a global auto-increment
+ * that persists across all ship creations. */
+void bc_ship_assign_subsystem_ids(bc_ship_state_t *ship,
+                                   const bc_ship_class_t *cls,
+                                   i32 *counter);
 
 /* Serialize ship state into an ObjectCreateTeam ship blob.
  * Returns bytes written, or -1 on error. */

--- a/include/openbc/transport.h
+++ b/include/openbc/transport.h
@@ -108,8 +108,18 @@ bool bc_outbox_add_reliable(bc_outbox_t *outbox, const u8 *payload, int len, u16
 /* Queue an ACK for a received reliable message. Returns true on success. */
 bool bc_outbox_add_ack(bc_outbox_t *outbox, u16 seq, u8 flags);
 
+/* Queue a fragment ACK: [0x01][seqHi][0x00][0x01][frag_idx]
+ * The is_fragmented flag (0x01) and frag_idx byte tell the client
+ * which specific fragment was received, draining its retransmit queue. */
+bool bc_outbox_add_fragment_ack(bc_outbox_t *outbox, u16 seq, u8 frag_idx);
+
 /* Queue a keepalive message (type 0x00, 2 bytes). Returns true on success. */
 bool bc_outbox_add_keepalive(bc_outbox_t *outbox);
+
+/* Queue a keepalive with identity data: [0x00][totalLen][payload...]
+ * Used to echo the client's cached identity data (22 bytes) back.
+ * Must use type 0x00, NOT 0x32 game data. */
+bool bc_outbox_add_keepalive_data(bc_outbox_t *outbox, const u8 *payload, int len);
 
 /* Flush accumulated messages to a buffer (for testing without sockets).
  * Sets buf[0]=BC_DIR_SERVER, buf[1]=msg_count, copies to out.

--- a/src/game/ship_data.c
+++ b/src/game/ship_data.c
@@ -1,5 +1,6 @@
 #include "openbc/ship_data.h"
 #include "openbc/json_parse.h"
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -215,6 +216,17 @@ static bool load_ship(bc_ship_class_t *ship, const json_value_t *obj)
         for (size_t i = 0; i < n; i++) {
             load_subsystem(&ship->subsystems[i], json_array_get(subs, i));
         }
+    }
+
+    /* Compute bounding extent from subsystem positions */
+    {
+        f32 max_dist = 0.0f;
+        for (int i = 0; i < ship->subsystem_count; i++) {
+            bc_vec3_t p = ship->subsystems[i].position;
+            f32 d = sqrtf(p.x*p.x + p.y*p.y + p.z*p.z);
+            if (d > max_dist) max_dist = d;
+        }
+        ship->bounding_extent = max_dist > 0.0f ? max_dist : 1.0f;
     }
 
     /* Serialization list (must be after subsystems are loaded) */

--- a/src/protocol/game_builders.c
+++ b/src/protocol/game_builders.c
@@ -176,6 +176,47 @@ int bc_build_end_game(u8 *buf, int buf_size, i32 reason)
     return (int)b.pos;
 }
 
+int bc_build_python_subsystem_event(u8 *buf, int buf_size,
+                                     i32 event_type,
+                                     i32 source_obj_id,
+                                     i32 dest_obj_id)
+{
+    /* Wire: [0x06][factory=0x101:i32][event_type:i32][source:i32][dest:i32]
+     * 17 bytes total. */
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, (size_t)buf_size);
+
+    if (!bc_buf_write_u8(&b, BC_OP_PYTHON_EVENT)) return -1;
+    if (!bc_buf_write_i32(&b, BC_FACTORY_SUBSYSTEM_EVENT)) return -1;
+    if (!bc_buf_write_i32(&b, event_type)) return -1;
+    if (!bc_buf_write_i32(&b, source_obj_id)) return -1;
+    if (!bc_buf_write_i32(&b, dest_obj_id)) return -1;
+
+    return (int)b.pos;
+}
+
+int bc_build_python_exploding_event(u8 *buf, int buf_size,
+                                     i32 source_obj_id,
+                                     i32 firing_player_id,
+                                     f32 lifetime)
+{
+    /* Wire: [0x06][factory=0x8129:i32][event_type=0x4E:i32]
+     *   [source:i32][dest=-1:i32][killer_id:i32][lifetime:f32]
+     * 25 bytes total. */
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, (size_t)buf_size);
+
+    if (!bc_buf_write_u8(&b, BC_OP_PYTHON_EVENT)) return -1;
+    if (!bc_buf_write_i32(&b, BC_FACTORY_OBJECT_EXPLODING)) return -1;
+    if (!bc_buf_write_i32(&b, BC_EVENT_OBJECT_EXPLODING)) return -1;
+    if (!bc_buf_write_i32(&b, source_obj_id)) return -1;
+    if (!bc_buf_write_i32(&b, (i32)-1)) return -1;  /* dest = sentinel */
+    if (!bc_buf_write_i32(&b, firing_player_id)) return -1;
+    if (!bc_buf_write_f32(&b, lifetime)) return -1;
+
+    return (int)b.pos;
+}
+
 int bc_build_state_update(u8 *buf, int buf_size,
                            i32 object_id, f32 game_time, u8 dirty_flags,
                            const u8 *field_data, int field_data_len)

--- a/tests/test_dynamic_battle.c
+++ b/tests/test_dynamic_battle.c
@@ -199,7 +199,7 @@ static void ai_update(int idx, f32 dt)
                             bc_vec3_t impact = bc_vec3_normalize(
                                 bc_vec3_sub(tgt->ship.pos, p->ship.pos));
                             bc_combat_apply_damage(&tgt->ship, tgt->cls, dmg, 0.0f,
-                                                   impact, false);
+                                                   impact, false, 1.0f);
                             p->damage_dealt += dmg;
                             tgt->damage_taken += dmg;
                         }
@@ -238,7 +238,7 @@ static void ai_update(int idx, f32 dt)
                             }
                         }
                         bc_combat_apply_damage(&tgt->ship, tgt->cls, dmg, dmg_radius,
-                                               impact, (dmg_radius > 0.0f));
+                                               impact, (dmg_radius > 0.0f), 1.0f);
                         p->damage_dealt += dmg;
                         tgt->damage_taken += dmg;
                     }
@@ -619,7 +619,7 @@ TEST(galaxy_vs_shuttle_asymmetric)
                             bc_vec3_t imp = {0, 1, 0};
                             bc_combat_apply_damage(&shuttle, shuttle_cls,
                                                     galaxy_cls->subsystems[s].max_damage,
-                                                    0.0f, imp, false);
+                                                    0.0f, imp, false, 1.0f);
                             break;
                         }
                         cnt++;
@@ -637,7 +637,7 @@ TEST(galaxy_vs_shuttle_asymmetric)
                 /* Photon torpedo damage = 500, area-effect */
                 bc_vec3_t imp = {0, 1, 0};
                 bc_combat_apply_damage(&shuttle, shuttle_cls, 500.0f, 500.0f,
-                                        imp, true);
+                                        imp, true, 1.0f);
             }
         }
 
@@ -654,7 +654,7 @@ TEST(galaxy_vs_shuttle_asymmetric)
                             bc_vec3_t imp = {0, -1, 0};
                             bc_combat_apply_damage(&galaxy, galaxy_cls,
                                                     shuttle_cls->subsystems[s].max_damage,
-                                                    0.0f, imp, false);
+                                                    0.0f, imp, false, 1.0f);
                             break;
                         }
                         cnt++;

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -401,7 +401,7 @@ TEST(shield_absorbs_damage)
 
     /* Hit from the front (impact_dir = -fwd, i.e. toward the ship's front) */
     bc_vec3_t impact = {0, 1, 0}; /* toward the ship's forward */
-    bc_combat_apply_damage(&ship, cls, 100.0f, 0.0f, impact, false);
+    bc_combat_apply_damage(&ship, cls, 100.0f, 0.0f, impact, false, 1.0f);
 
     /* Shield should have absorbed it */
     ASSERT(ship.shield_hp[BC_SHIELD_FRONT] < front_before);
@@ -419,7 +419,7 @@ TEST(overflow_penetrates_hull)
     f32 hull_before = ship.hull_hp;
 
     bc_vec3_t impact = {0, 1, 0};
-    bc_combat_apply_damage(&ship, cls, 100.0f, 0.0f, impact, false);
+    bc_combat_apply_damage(&ship, cls, 100.0f, 0.0f, impact, false, 1.0f);
 
     /* Shield gone, hull damaged by overflow */
     ASSERT(ship.shield_hp[BC_SHIELD_FRONT] < 0.01f);
@@ -438,7 +438,7 @@ TEST(hull_zero_means_death)
     for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) ship.shield_hp[i] = 0;
 
     bc_vec3_t impact = {0, 1, 0};
-    bc_combat_apply_damage(&ship, cls, 99999.0f, 0.0f, impact, false);
+    bc_combat_apply_damage(&ship, cls, 99999.0f, 0.0f, impact, false, 1.0f);
     ASSERT(!ship.alive);
     ASSERT(ship.hull_hp < 0.01f);
 }


### PR DESCRIPTION
## Summary

Major rework of collision damage, power system wire encoding, PythonEvent generation for repair/death, and transport reliability improvements. 28 files changed across 8 subsystems.

### Collision & Combat System
- **Dual collision damage paths**: Path 1 (`raw * 0.1 + 0.1`, capped at 0.5) for fractional damage, Path 2 (`raw * 900 + 500`) for absolute HP damage with a dead zone at `raw <= 0.01`. Server uses Path 2 for CollisionEffect handling.
- **Shield scale multiplier**: Added `shield_scale` parameter to `bc_combat_apply_damage()` to support variable shield absorption capacity. Shields now compute `facing_capacity = shield_hp * shield_scale` and deduct using inverse scaling.
- **Bounding extent collision radius**: Collision subsystem localization now uses `bounding_extent * 0.5` (computed from subsystem positions at load time) instead of hardcoded values.
- **Collision ownership & dedup**: Server validates sender owns source or target, deduplicates ship-vs-ship collisions (target player reports their own), and rejects implausible collisions beyond 2000 units.

### Power System
- **Sign-bit encoding fix**: Health update power byte for disabled subsystems changed from `pct |= 0x80` (corrupts value) to `pct = (u8)(-(i8)pct)` (proper signed negation per wire spec). A subsystem at 50% OFF now correctly encodes as -50 instead of 178.
- **No-drain efficiency model**: `bc_ship_power_tick()` no longer deducts from `main_battery`/`backup_battery`. Efficiency is computed from conduit capacity vs demand using local shadow variables, matching stock BC dedi behavior where batteries always report 0xFF (100%).
- **Three power draw modes**: Added `BC_POWER_MODE_MAIN_FIRST` (0), `BC_POWER_MODE_BACKUP_FIRST` (1), `BC_POWER_MODE_BACKUP_ONLY` (2) with mode-aware conduit routing in efficiency computation. All vanilla subsystems default to mode 0.
- **125% overlock range**: `power_pct` field documented as 0-125 (not 0-100) to support the engineering panel overclocking mechanic.

### PythonEvent Support
- **Subsystem damage events**: Server generates `ADD_TO_REPAIR_LIST` PythonEvents when subsystems take damage, driving the client's repair queue UI and damage VFX/SFX.
- **Object exploding events**: Server sends `OBJECT_EXPLODING` PythonEvents on ship destruction (via beam, torpedo, or collision), with killer ID and lifetime fields.
- **Subsystem object ID assignment**: New `bc_ship_assign_subsystem_ids()` assigns sequential IDs from a global counter (`g_script_obj_counter = 16`, calibrated from stock dedi traces) in ser_list order.
- **PythonEvent builders**: New `bc_build_python_subsystem_event()` (17-byte) and `bc_build_python_exploding_event()` (25-byte) factory functions.

### Transport & Network
- **Fragment ACKs**: New `bc_outbox_add_fragment_ack()` sends 5-byte ACKs with fragment index to drain client retransmit queues.
- **Keepalive data echo**: New `bc_outbox_add_keepalive_data()` echoes cached client identity data as type 0x00 keepalive (not type 0x32).
- **Volatile write barriers in peer**: Expanded volatile pointer workaround in `bc_peers_add()` to protect `state`, `object_id`, and `class_index` fields from i686-w64-mingw32-gcc -O2 dead-store elimination.

### Server
- **Health broadcast rate**: Increased from ~2Hz (every 15 ticks) to 10Hz (every 3 ticks) matching stock dedi rate for smooth F5 panel updates.
- **Score tracking on kills**: Collision, beam, and torpedo kills now update killer/victim scores and send ScoreChange events. Frag limit checked on all kill paths.
- **Respawn with subsystem IDs**: Respawn queue now calls `bc_ship_assign_subsystem_ids()` so respawned ships have correct PythonEvent object IDs.

### Build & Config
- **Header dependency generation**: Added `DEPFLAGS` (`-MMD -MP`) to Makefile for automatic `.d` file generation, with `-include` for incremental rebuilds.
- **`.gitignore`**: Added `openbc-*.log` pattern.

### Documentation (4 new docs, 3 updated)
- **New**: `power-system.md` (power initialization, player adjustment, wire format spec), `repair-system.md`, `pythonevent-wire-format.md`, `collision-shield-interaction.md`, `fix-collision-shield-absorption.md`
- **Updated**: `combat-system.md` (dual damage paths, repair priority toggle), `collision-detection-system.md` (path1/path2 formulas), `collision-damage-event-chain.md` (repair event names)

## Test plan
- [x] `make all PLATFORM=Windows` -- clean build, zero warnings
- [x] `make test PLATFORM=Windows` -- 11/11 test suites pass
- [ ] Manual test: connect stock BC client, verify F5 Engineering panel shows 100% power on spawn
- [ ] Manual test: collide two ships, verify damage applied and repair queue populates
- [ ] Manual test: destroy a ship, verify explosion VFX plays on all clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)