### PR TITLE
Fix scoreboard player visibility by using network player IDs (issue #5)

### DIFF
--- a/docs/join-flow.md
+++ b/docs/join-flow.md
@@ -157,8 +157,10 @@ The server responds with:
 
 2. **Score (0x37)**: Current scores for all players (zeros for new game)
    ```
-   [0x37][count:u8][{slot:u8, score:i32le}...]
+   [0x37][player_id:i32][kills:i32][deaths:i32][score:i32]
    ```
+   One `0x37` message is sent per player (not batched). `player_id` is the
+   network player ID (`GetNetID()` / wire slot), not an object ID.
 
 3. **ObjCreateTeam (0x03)**: One per already-spawned ship (for late joiners)
    ```
@@ -173,7 +175,7 @@ The server responds with:
 ### Late-Join Data
 
 When a player joins an in-progress game, the server sends the full game state:
-- Score message (0x37) with all current scores
+- Score message(s) (0x37), one per player, with current kills/deaths/score
 - One ObjCreateTeam (0x03) for every already-spawned ship (cached from original creation)
 - DeletePlayerUI (0x17) for each connected player
 

--- a/docs/phase1-verified-protocol.md
+++ b/docs/phase1-verified-protocol.md
@@ -630,7 +630,7 @@ Per-player score synchronization. The server sends **one 0x37 message per existi
 Field             Type       Size   Notes
 -----             ----       ----   -----
 opcode            u8         1      0x37
-playerId          i32 LE     4      Player's object ID (from GetObjID())
+playerId          i32 LE     4      Network player ID (GetNetID()/wire slot)
 kills             i32 LE     4      Kill count
 deaths            i32 LE     4      Death count
 score             i32 LE     4      Current score (signed, can be negative)
@@ -648,15 +648,15 @@ Sent when a kill occurs. Contains updated kill/death/score counts for the killer
 Field             Type       Size   Notes
 -----             ----       ----   -----
 opcode            u8         1      0x36
-killerId          i32 LE     4      Killer's object ID (0 for environmental kills)
+killerId          i32 LE     4      Killer's network player ID (0 for environmental kills)
 [if killerId != 0:]
   killerKills     i32 LE     4      Killer's updated kill count
   killerScore     i32 LE     4      Killer's updated score
-victimId          i32 LE     4      Victim's object ID
+victimId          i32 LE     4      Victim's network player ID
 victimDeaths      i32 LE     4      Victim's updated death count
 updateCount       u8         1      Number of extra score updates
 [repeated updateCount times:]
-  playerId        i32 LE     4      Player's object ID
+  playerId        i32 LE     4      Player's network player ID
   score           i32 LE     4      Player's updated score
 ```
 

--- a/docs/script-message-wire-format.md
+++ b/docs/script-message-wire-format.md
@@ -305,24 +305,22 @@ Direction: Host → joining client (sent after client sends NewPlayerInGame 0x2A
 Offset  Size  Type    Field
 ------  ----  ----    -----
 0       1     u8      opcode = 0x36
-1       4     i32     killed_player_id
-5       4     i32     killer_player_id (0 if suicide/environment)
+1       4     i32     killer_player_id (0 if suicide/environment)
 [if killer_player_id != 0:]
-9       4     i32     killer_score_delta
-13      4     i32     killer_deaths_delta
+5       4     i32     killer_kills
+9       4     i32     killer_score
 [end if]
-+0      4     i32     killed_score_delta
-+4      4     i32     killed_deaths_delta
++0      4     i32     victim_player_id
++4      4     i32     victim_deaths
 +8      1     u8      update_count (number of additional score entries)
 [repeated update_count times:]
   +0    4     i32     player_id
-  +4    4     i32     kills
-  +8    4     i32     deaths
-  +12   4     i32     score
+  +4    4     i32     score
 [end repeat]
 ```
 
 Direction: Host → all clients (broadcast on kill)
+All player IDs in this message use the network ID domain (`GetNetID()` / wire slot).
 
 ### SCORE_MESSAGE (0x37)
 
@@ -330,16 +328,14 @@ Direction: Host → all clients (broadcast on kill)
 Offset  Size  Type    Field
 ------  ----  ----    -----
 0       1     u8      opcode = 0x37
-1       1     u8      player_count
-[repeated player_count times:]
-  +0    4     i32     player_id
-  +4    4     i32     kills
-  +8    4     i32     deaths
-  +12   4     i32     score
-[end repeat]
+1       4     i32     player_id
+5       4     i32     kills
+9       4     i32     deaths
+13      4     i32     score
 ```
 
-Direction: Host → joining client (full score roster sync)
+Direction: Host → joining client (full score roster sync, one message per player)
+`player_id` uses the network ID domain (`GetNetID()` / wire slot).
 
 ### END_GAME_MESSAGE (0x38)
 

--- a/include/openbc/game_builders.h
+++ b/include/openbc/game_builders.h
@@ -65,6 +65,7 @@ int bc_build_chat(u8 *buf, int buf_size,
 
 /* Score: [0x37][player_id:i32][kills:i32][deaths:i32][score:i32]
  * 17 bytes total. Sent once per player to a newly joining client.
+ * player_id is the network player ID (GetNetID()/wire_slot), not object_id.
  * Stock BC sends one message per player (not batched). */
 int bc_build_score(u8 *buf, int buf_size,
                     i32 player_id, i32 kills, i32 deaths, i32 score);
@@ -73,6 +74,7 @@ int bc_build_score(u8 *buf, int buf_size,
  *              [victim_id:i32][deaths:i32][update_count:u8]
  *              [{player_id:i32, score:i32}...]
  * Variable length. Sent when a kill occurs. killer_id=0 for environmental kills.
+ * killer_id/victim_id/player_id use network player IDs (GetNetID()/wire_slot).
  * extra_scores is an array of {player_id, score} pairs for damage-share updates. */
 typedef struct {
     i32 player_id;

--- a/include/openbc/player_ids.h
+++ b/include/openbc/player_ids.h
@@ -1,0 +1,30 @@
+#ifndef OPENBC_PLAYER_IDS_H
+#define OPENBC_PLAYER_IDS_H
+
+#include "openbc/types.h"
+#include "openbc/opcodes.h"
+
+/*
+ * Score messages (0x36/0x37) use the network player ID domain:
+ * the same IDs returned by client GetNetID() (wire_slot numbering),
+ * not ship/object IDs.
+ */
+
+static inline i32 bc_player_id_from_peer_slot(int peer_slot)
+{
+    if (peer_slot < 0 || peer_slot >= BC_MAX_PLAYERS) return 0;
+    return (i32)(peer_slot + 1);  /* wire_slot */
+}
+
+static inline i32 bc_player_id_from_game_slot(int game_slot)
+{
+    /* game_slot 0 maps to peer_slot 1 on dedicated server */
+    return bc_player_id_from_peer_slot(game_slot + 1);
+}
+
+static inline bool bc_is_valid_player_id(i32 player_id)
+{
+    return player_id > 0 && player_id <= BC_MAX_PLAYERS;
+}
+
+#endif /* OPENBC_PLAYER_IDS_H */

--- a/src/protocol/game_builders.c
+++ b/src/protocol/game_builders.c
@@ -138,6 +138,7 @@ int bc_build_score_change(u8 *buf, int buf_size,
      *   [if killer_id != 0: kills:i32, killer_score:i32]
      *   [victim_id:i32][deaths:i32]
      *   [update_count:u8][{player_id:i32, score:i32}...]
+     * IDs are network player IDs (GetNetID()/wire_slot), not object IDs.
      */
     bc_buffer_t b;
     bc_buf_init(&b, buf, (size_t)buf_size);
@@ -241,7 +242,8 @@ int bc_build_score(u8 *buf, int buf_size,
 {
     /* Wire format (from stock Mission1.py SendScoreMessage):
      *   [0x37][player_id:i32][kills:i32][deaths:i32][score:i32]
-     * 17 bytes total. One message per player. */
+     * 17 bytes total. One message per player.
+     * player_id is the network player ID (GetNetID()/wire_slot). */
     bc_buffer_t b;
     bc_buf_init(&b, buf, (size_t)buf_size);
 

--- a/src/server/server_handshake.c
+++ b/src/server/server_handshake.c
@@ -9,6 +9,7 @@
 #include "openbc/master.h"
 #include "openbc/game_events.h"
 #include "openbc/game_builders.h"
+#include "openbc/player_ids.h"
 #include "openbc/ship_state.h"
 #include "openbc/log.h"
 
@@ -84,9 +85,15 @@ static void send_settings_and_gameinit(int peer_slot)
         int sent = 0;
         for (int i = 1; i < BC_MAX_PLAYERS; i++) {
             if (g_peers.peers[i].state >= PEER_LOBBY) {
+                i32 player_id = bc_player_id_from_peer_slot(i);
+                if (!bc_is_valid_player_id(player_id)) {
+                    LOG_WARN("handshake", "slot=%d skipping Score for invalid peer slot %d",
+                             peer_slot, i);
+                    continue;
+                }
                 u8 score_buf[32];
                 int slen = bc_build_score(score_buf, sizeof(score_buf),
-                                           g_peers.peers[i].ship.object_id,
+                                           player_id,
                                            g_peers.peers[i].kills,
                                            g_peers.peers[i].deaths,
                                            g_peers.peers[i].score);

--- a/tests/test_player_ids.c
+++ b/tests/test_player_ids.c
@@ -1,0 +1,41 @@
+#include "test_util.h"
+#include "openbc/player_ids.h"
+#include "openbc/opcodes.h"
+
+TEST(peer_slot_to_player_id)
+{
+    ASSERT_EQ_INT(bc_player_id_from_peer_slot(0), 1);
+    ASSERT_EQ_INT(bc_player_id_from_peer_slot(1), 2);
+    ASSERT_EQ_INT(bc_player_id_from_peer_slot(6), 7);
+}
+
+TEST(game_slot_to_player_id)
+{
+    ASSERT_EQ_INT(bc_player_id_from_game_slot(0), 2);
+    ASSERT_EQ_INT(bc_player_id_from_game_slot(1), 3);
+    ASSERT_EQ_INT(bc_player_id_from_game_slot(5), 7);
+}
+
+TEST(invalid_slot_returns_zero)
+{
+    ASSERT_EQ_INT(bc_player_id_from_peer_slot(-1), 0);
+    ASSERT_EQ_INT(bc_player_id_from_peer_slot(BC_MAX_PLAYERS), 0);
+    ASSERT_EQ_INT(bc_player_id_from_game_slot(-2), 0);
+    ASSERT_EQ_INT(bc_player_id_from_game_slot(BC_MAX_PLAYERS), 0);
+}
+
+TEST(validity_check)
+{
+    ASSERT(!bc_is_valid_player_id(0));
+    ASSERT(bc_is_valid_player_id(1));
+    ASSERT(bc_is_valid_player_id(2));
+    ASSERT(bc_is_valid_player_id(BC_MAX_PLAYERS));
+    ASSERT(!bc_is_valid_player_id(BC_MAX_PLAYERS + 1));
+}
+
+TEST_MAIN_BEGIN()
+    RUN(peer_slot_to_player_id);
+    RUN(game_slot_to_player_id);
+    RUN(invalid_slot_returns_zero);
+    RUN(validity_check);
+TEST_MAIN_END()


### PR DESCRIPTION
## Summary
- fix SCORE_MESSAGE (0x37) and SCORE_CHANGE_MESSAGE (0x36) producers to use network player IDs (GetNetID/wire-slot domain) instead of object IDs
- add player_ids helpers and validity checks to prevent ID-domain regressions
- add score message wire-format tests and player-id mapping tests
- align docs for score message structure and ID semantics

## Validation
- ./build/tests/test_game_builders (21/21)
- ./build/tests/test_player_ids (4/4)
- make test (network/socket-dependent suites fail in this environment with socket() failed: 1; non-network suites pass)

Closes #5

@Cadacious please review when you have a chance.