### PR TITLE
docs: Add per-subsystem power mode assignments

### DIFF
--- a/docs/power-system.md
+++ b/docs/power-system.md
@@ -119,6 +119,48 @@ The efficiency ratio scales subsystem performance:
 - **Engines**: Acceleration/speed scaled by efficiency
 - **No hard cutoff**: Subsystems don't turn off. At efficiency 0.0, they simply provide zero capability. Gradually increasing power gradually restores functionality.
 
+### Per-Subsystem Power Mode Assignments
+
+Each subsystem type has a fixed power draw mode assigned at construction time:
+
+| Subsystem | Power Mode | Behavior |
+|-----------|-----------|----------|
+| Shields | 0 (main-first) | Standard draw |
+| Sensors | 0 (main-first) | Standard draw |
+| Impulse engines | 0 (main-first) | Standard draw |
+| Warp engines | 0 (main-first) | Standard draw |
+| Phasers | 0 (main-first) | Standard draw |
+| Torpedoes | 0 (main-first) | Standard draw |
+| Pulse weapons | 0 (main-first) | Standard draw |
+| Repair | 0 (main-first) | Standard draw |
+| **Tractor beams** | **1 (backup-first)** | Draws from backup battery first, then main as fallback |
+| **Cloaking device** | **2 (backup-only)** | Draws exclusively from backup battery; never touches main |
+
+Only **2 of 11** subsystem types override the default power mode. This creates a power priority hierarchy:
+
+1. **Main battery** (mode 0): Reserved for combat-critical systems (weapons, shields, engines, sensors). These get first access to the primary power reservoir.
+2. **Backup battery** (mode 1): Tractor beams draw from backup first. This prevents tractor operations from draining combat power unless the backup battery is exhausted.
+3. **Backup-only** (mode 2): The cloaking device is completely isolated from the main power grid. It can only operate while the backup battery has charge, creating a natural time limit on cloak duration and making it impossible for cloaking to starve combat systems.
+
+This is consistent with Star Trek engineering: backup/auxiliary power for stealth and utility systems, primary power for weapons and shields.
+
+### Shield Recharge Special Path
+
+When the shield subsystem itself is destroyed (condition = 0), individual shield facings that are still intact need recharge power. In this scenario, the shield system draws directly from the **backup battery** using a hardcoded path that bypasses the normal power mode switch.
+
+This is NOT driven by the shield's power mode (which remains mode 0). It is a separate code path specifically for the dead-shield recovery state:
+
+```
+Shield Update:
+  if shield subsystem is alive AND enabled:
+    → Normal path: recharge facings using power from mode 0 (main-first)
+  else (shield subsystem destroyed OR disabled):
+    → Recovery path: for each surviving facing, draw from backup battery directly
+    → Excess power returned to backup battery after recharge
+```
+
+This design means damaged shields preferentially consume backup batteries during recovery, preserving main battery charge for active combat systems during the vulnerable period when shields are down.
+
 ---
 
 ## Power Initialization on Ship Spawn


### PR DESCRIPTION
## Summary

- Documents the fixed power draw mode for all 11 subsystem types in the power system spec
- Tractor beam uses mode 1 (backup-first), cloaking device uses mode 2 (backup-only), all other subsystems use mode 0 (main-first)
- Documents the shield dead-recharge special path that bypasses the normal power mode switch to draw directly from backup batteries

## Context

Corrects the assumption in issue #1 that cloaking uses mode 1 (backup-first). Verified behavior is mode 2 (backup-only) — the cloaking device is completely isolated from the main power grid.

## Test plan

- [ ] Review per-subsystem power mode table against power-system.md draw mode descriptions
- [ ] Verify clean-room compliance (no binary addresses or function names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)