### PR TITLE
fix: respawn ObjCreateTeam was crashing clients on death (#28)

### DIFF
--- a/src/server/main.c
+++ b/src/server/main.c
@@ -855,17 +855,53 @@ int main(int argc, char **argv)
                     bc_ship_assign_subsystem_ids(&rp->ship, rcls,
                                                   &g_script_obj_counter);
 
-                    u8 cpkt[1024];
-                    int clen = bc_ship_build_create_packet(&rp->ship, rcls,
-                                                            cpkt, sizeof(cpkt));
-                    if (clen > 0) {
-                        if (clen <= (int)sizeof(rp->spawn_payload)) {
-                            memcpy(rp->spawn_payload, cpkt, (size_t)clen);
-                            rp->spawn_len = clen;
-                        }
-                        bc_send_to_all(cpkt, clen, true);
-                        LOG_INFO("game", "slot=%d respawned as %s", i, rcls->name);
+                    /* Build respawn ObjCreateTeam by patching the cached
+                     * initial-spawn payload with the new position.  This
+                     * preserves the exact wire format the client originally
+                     * sent (factory_class_id prefix, owner byte, species,
+                     * name/set strings, subsystem state format), avoiding the
+                     * crash that occurred when bc_ship_build_create_packet
+                     * produced a different layout missing the factory_class_id.
+                     *
+                     * Fixed-header offsets:
+                     *   0:     opcode  (0x03)
+                     *   1:     owner_slot   (preserved from initial spawn)
+                     *   2:     team_id
+                     *   3-6:   factory_class_id  (0x00008008 for ships)
+                     *   7-10:  object_id
+                     *   11:    species_type
+                     *   12-15: pos_x  (f32, little-endian)
+                     *   16-19: pos_y
+                     *   20-23: pos_z
+                     */
+                    if (rp->spawn_len < 24) continue;
+
+                    u8 cpkt[256];
+                    int clen = rp->spawn_len;
+                    if (clen > (int)sizeof(cpkt)) clen = (int)sizeof(cpkt);
+                    memcpy(cpkt, rp->spawn_payload, (size_t)clen);
+
+                    /* Patch team byte and position */
+                    cpkt[2] = team_id;
+                    {
+                        u32 bx, by, bz;
+                        memcpy(&bx, &rp->ship.pos.x, 4);
+                        memcpy(&by, &rp->ship.pos.y, 4);
+                        memcpy(&bz, &rp->ship.pos.z, 4);
+                        cpkt[12] = (u8)(bx);        cpkt[13] = (u8)(bx >> 8);
+                        cpkt[14] = (u8)(bx >> 16);  cpkt[15] = (u8)(bx >> 24);
+                        cpkt[16] = (u8)(by);        cpkt[17] = (u8)(by >> 8);
+                        cpkt[18] = (u8)(by >> 16);  cpkt[19] = (u8)(by >> 24);
+                        cpkt[20] = (u8)(bz);        cpkt[21] = (u8)(bz >> 8);
+                        cpkt[22] = (u8)(bz >> 16);  cpkt[23] = (u8)(bz >> 24);
                     }
+
+                    /* Update cached spawn payload for late-joiners */
+                    memcpy(rp->spawn_payload, cpkt, (size_t)clen);
+                    rp->spawn_len = clen;
+
+                    bc_send_to_all(cpkt, clen, true);
+                    LOG_INFO("game", "slot=%d respawned as %s", i, rcls->name);
                 }
             }
 

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -602,9 +602,8 @@ static void apply_beam_damage(int shooter_slot, int target_slot)
 
         process_ship_kill(shooter_slot, target_slot, false);
 
-        /* Clear victim ship state */
+        /* Clear victim ship state (keep spawn_payload as respawn template) */
         target->has_ship = false;
-        target->spawn_len = 0;
         if (!g_game_ended) {
             target->respawn_timer = 5.0f;
             target->respawn_class = target->class_index;
@@ -702,8 +701,8 @@ void bc_torpedo_hit_callback(int shooter_slot, i32 target_id,
 
         process_ship_kill(shooter_slot, target_slot, false);
 
+        /* Keep spawn_payload as respawn template; only clear has_ship */
         target->has_ship = false;
-        target->spawn_len = 0;
         if (!g_game_ended) {
             target->respawn_timer = 5.0f;
             target->respawn_class = target->class_index;
@@ -1273,9 +1272,8 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
         /* Score: death for self, no killer player (killer_slot=-1). */
         process_ship_kill(-1, peer_slot, true);
 
-        /* Clear ship state and schedule respawn */
+        /* Clear ship state and schedule respawn (keep spawn_payload as template) */
         peer->has_ship = false;
-        peer->spawn_len = 0;
         if (!g_game_ended) {
             peer->respawn_timer = 5.0f;
             peer->respawn_class = peer->class_index;
@@ -1464,8 +1462,8 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
                             if (blen > 0)
                                 bc_send_to_all(boom, blen, true);
                         }
+                        /* Keep spawn_payload as respawn template; only clear has_ship */
                         target->has_ship = false;
-                        target->spawn_len = 0;
                         if (!g_game_ended) {
                             target->respawn_timer = 5.0f;
                             target->respawn_class = target->class_index;
@@ -1600,8 +1598,8 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
                                 if (blen2 > 0)
                                     bc_send_to_all(boom2, blen2, true);
                             }
+                            /* Keep spawn_payload as respawn template; only clear has_ship */
                             source->has_ship = false;
-                            source->spawn_len = 0;
                             if (!g_game_ended) {
                                 source->respawn_timer = 5.0f;
                                 source->respawn_class =

--- a/src/server/server_handshake.c
+++ b/src/server/server_handshake.c
@@ -255,7 +255,7 @@ static void send_settings_and_gameinit(int peer_slot)
     for (int i = 1; i < BC_MAX_PLAYERS; i++) {
         if (i == peer_slot) continue;
         bc_peer_t *other = &g_peers.peers[i];
-        if (other->state >= PEER_LOBBY && other->spawn_len > 0) {
+        if (other->state >= PEER_LOBBY && other->has_ship && other->spawn_len > 0) {
             bc_queue_reliable(peer_slot, other->spawn_payload, other->spawn_len);
             LOG_DEBUG("handshake", "slot=%d forwarding spawn from slot %d (%d bytes)",
                       peer_slot, i, other->spawn_len);
@@ -323,7 +323,7 @@ void bc_handle_peer_disconnect(int slot)
         int len;
 
         /* 1. DestroyObject (0x14) -- remove ship from game world */
-        if (g_peers.peers[slot].spawn_len > 0) {
+        if (g_peers.peers[slot].has_ship) {
             i32 ship_id = g_peers.peers[slot].object_id;
             if (ship_id < 0) {
                 /* Fallback: compute from game_slot */


### PR DESCRIPTION
Fixes #28.

## The Crime Scene

Every time a ship died and the server sent the respawn `ObjCreateTeam` (opcode `0x03`), the client exploded — not with a cool explosion, but with an access violation. Here's the murder weapon:

`bc_ship_serialize()` was building the ship blob in a completely wrong wire format, missing the 4-byte `factory_class_id` prefix (`0x00008008`) that **must** appear at byte 0 of the object payload. Without it:

1. Client reads bytes 0–3 as the factory class ID
2. Gets `0x3FFFFFFF` (the object ID, sitting where class ID should be)
3. `0x3FFFFFFF` is not a registered factory → factory returns `NULL`
4. Client calls a virtual method on `NULL`
5. Access violation. Ship death takes the client with it.

Beyond the missing prefix, the old serializer had a whole bouquet of problems:
- Species as `u16` (wire expects `u8`)
- Extra forward/up rotation vectors that don't belong in `ObjCreateTeam`
- Wrong subsystem state format (flat `f32[]` instead of the hierarchical condition-byte format)
- `owner` byte was `peer_slot` (1-based) instead of `game_slot` (0-based, what the client sent)
- ~198 bytes total vs ~110 for a valid spawn — completely different shape

## The Fix

Instead of rewriting `bc_ship_serialize` to match the full wire format (complex, fragile), the respawn now **reuses the cached initial-spawn payload** — the exact `ObjCreateTeam` bytes the client sent at join time — and **patches only the 12 position bytes** at their known fixed offsets (12–23):

```
[0x03][owner][team][class_id:4][obj_id:4][species:1][pos_x:4][pos_y:4][pos_z:4][...]
  0     1      2     3-6         7-10      11          12-15    16-19    20-23
                ↑ team patch                            ↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑ position patch
```

This approach is correct because:
- `factory_class_id`, `object_id`, `species`, player name, set name, and subsystem state format are all **identical at respawn** — same ship, same player, fresh full health
- Only the spawn position (random) and team (in case it changed) need updating
- The client already knows how to parse this format because it wrote it

## Supporting Changes

**`server_dispatch.c`** — `spawn_len = 0` is no longer set on kills. The `spawn_payload` buffer needs to survive the death so the respawn code has a valid template. `has_ship` now carries the "is this ship alive" semantic.

**`server_handshake.c`** — Late-joiner relay and disconnect `DestroyObject` now gate on `has_ship` instead of `spawn_len > 0`. Semantically more correct: dead players shouldn't be spawned in for new joiners, and disconnecting while dead shouldn't fire a redundant `DestroyObject`.

## Test Results

```
=== Running tests ===
  test_battle                              PASS
  test_checksum                            PASS
  test_client_transport                    PASS
  test_dynamic_battle                      PASS
  test_game_builders                       PASS
  test_game_events                         PASS
  test_gamespy                             PASS
  test_json                                PASS
  test_networked_battle                    PASS
  test_player_ids                          PASS
  test_protocol                            PASS
  test_registry                            PASS
=== 12 passed, 0 failed ===
```

Zero warnings. @Cadacious 👊🕺

🤖 Generated with [Claude Code](https://claude.com/claude-code)