### PR TITLE
fix: move spawn_len guard before ship state init in respawn loop

### DIFF
--- a/src/server/main.c
+++ b/src/server/main.c
@@ -838,6 +838,7 @@ int main(int argc, char **argv)
                     const bc_ship_class_t *rcls =
                         bc_registry_get_ship(&g_registry, rp->respawn_class);
                     if (!rcls) continue;
+                    if (rp->spawn_len < 24) continue;
 
                     u8 team_id = g_player_teams[i];
                     if (team_id == BC_TEAM_NONE) team_id = rp->ship.team_id;
@@ -874,8 +875,6 @@ int main(int argc, char **argv)
                      *   16-19: pos_y
                      *   20-23: pos_z
                      */
-                    if (rp->spawn_len < 24) continue;
-
                     u8 cpkt[256];
                     int clen = rp->spawn_len;
                     if (clen > (int)sizeof(cpkt)) clen = (int)sizeof(cpkt);


### PR DESCRIPTION
## Summary

- Moves the `spawn_len < 24` truncation guard to before `bc_ship_init` / `has_ship = true` in the respawn loop
- Previously, a malformed ObjCreateTeam packet with `spawn_len < 24` would cause `has_ship` to be set `true` before the `continue`, permanently locking the peer out of future respawns
- The per-tick guard at line 831 (`rp->has_ship`) would skip the peer every subsequent tick, so it could never respawn again

Fixes #30.

## Test plan

- [x] Zero warnings under `-Wall -Wextra -Wpedantic`
- [x] All 12 test suites pass (`make test`)
- [x] Respawn loop logic reviewed: guard now fires before any ship state mutation

🤖 Generated with [Claude Code](https://claude.com/claude-code)