### PR TITLE
security: add recursion depth limit to parse_file_tree (#46)

### DIFF
--- a/src/protocol/handshake.c
+++ b/src/protocol/handshake.c
@@ -204,6 +204,11 @@ int bc_delete_player_anim_build(u8 *buf, int buf_size,
 
 /* --- Checksum response parsing --- */
 
+/* Maximum nesting depth for parse_file_tree().
+ * Real BC directory trees are 3-4 levels deep; 16 is very generous.
+ * This prevents a crafted payload from exhausting the stack via deep recursion. */
+#define BC_MAX_TREE_DEPTH 16
+
 /* Parse a recursive file tree from a buffer.
  * Wire format (self-describing, same at every nesting level):
  *   [file_count:u16 LE][files × {name_hash:u32, content_hash:u32}]
@@ -213,11 +218,18 @@ int bc_delete_player_anim_build(u8 *buf, int buf_size,
  *
  * If files/file_count are non-NULL, stores file entries (up to max_files).
  * If resp is non-NULL, stores first-level subdirectory data in resp->subdirs.
- * Nested subdirectories (level 2+) are consumed without storing. */
+ * Nested subdirectories (level 2+) are consumed without storing.
+ * depth tracks recursion level; call sites pass 0 and each recursive call passes depth+1. */
 static bool parse_file_tree(bc_buffer_t *b,
                             bc_checksum_file_t *files, int *file_count, int max_files,
-                            bc_checksum_resp_t *resp)
+                            bc_checksum_resp_t *resp,
+                            int depth)
 {
+    if (depth > BC_MAX_TREE_DEPTH) {
+        LOG_WARN("checksum", "tree: recursion depth %d exceeds limit", depth);
+        return false;
+    }
+
     u16 fc;
     if (!bc_buf_read_u16(b, &fc)) {
         LOG_DEBUG("checksum", "tree: failed to read file_count at pos=%d",
@@ -273,11 +285,11 @@ static bool parse_file_tree(bc_buffer_t *b,
                     resp->subdirs[i].data.files,
                     &resp->subdirs[i].data.file_count,
                     BC_CHECKSUM_MAX_SUB_FILES,
-                    NULL))
+                    NULL, depth + 1))
                 return false;
         } else {
             /* Consume bytes without storing */
-            if (!parse_file_tree(b, NULL, NULL, 0, NULL))
+            if (!parse_file_tree(b, NULL, NULL, 0, NULL, depth + 1))
                 return false;
         }
     }
@@ -335,7 +347,7 @@ bool bc_checksum_response_parse(bc_checksum_resp_t *resp,
      * No need for a recursive flag — the parser recurses when subdir_count > 0. */
     if (!parse_file_tree(&b,
             resp->files, &resp->file_count, BC_CHECKSUM_MAX_RESP_FILES,
-            resp)) {
+            resp, 0)) {
         LOG_DEBUG("checksum", "parse: round=%d file_tree parse failed "
                   "at pos=%d", index, (int)b.pos);
         return false;

--- a/tests/test_protocol.c
+++ b/tests/test_protocol.c
@@ -921,6 +921,37 @@ TEST(checksum_resp_validate_file_missing)
     ASSERT_EQ_INT(bc_checksum_response_validate(&resp, &dir), CHECKSUM_FILE_MISSING);
 }
 
+TEST(checksum_resp_parse_depth_limit)
+{
+    /* Build a crafted payload with 18 nesting levels (beyond BC_MAX_TREE_DEPTH=16).
+     * Wire format per level with 0 files and 1 subdir:
+     *   [file_count:u16=0][subdir_count:u8=1][name_hash:u32]
+     * Each level is 7 bytes; 18 levels = 126 bytes of tree data.
+     * depth=17 (>16) triggers the guard and parse must return false. */
+    u8 buf[256];
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, sizeof(buf));
+
+    /* Header: opcode, round=0, ref_hash, dir_hash */
+    bc_buf_write_u8(&b, BC_OP_CHECKSUM_RESP);
+    bc_buf_write_u8(&b, 0);          /* round 0 */
+    bc_buf_write_u32(&b, 0x11111111); /* ref_hash */
+    bc_buf_write_u32(&b, 0x22222222); /* dir_hash */
+
+    /* 18 nested levels, each: file_count=0, subdir_count=1, name_hash */
+    for (int i = 0; i < 18; i++) {
+        bc_buf_write_u16(&b, 0);         /* file_count = 0 */
+        bc_buf_write_u8(&b, 1);          /* subdir_count = 1 */
+        bc_buf_write_u32(&b, 0xDEAD0000 + (u32)i); /* name_hash */
+    }
+    /* Leaf level that would follow if depth were not limited */
+    bc_buf_write_u16(&b, 0); /* file_count = 0 */
+    bc_buf_write_u8(&b, 0);  /* subdir_count = 0 */
+
+    bc_checksum_resp_t resp;
+    ASSERT(!bc_checksum_response_parse(&resp, buf, (int)b.pos));
+}
+
 /* === UICollisionSetting tests === */
 
 TEST(ui_collision_build)
@@ -1693,6 +1724,7 @@ TEST_MAIN_BEGIN()
     RUN(checksum_resp_validate_content_mismatch);
     RUN(checksum_resp_validate_dir_mismatch);
     RUN(checksum_resp_validate_file_missing);
+    RUN(checksum_resp_parse_depth_limit);
 
     /* Fragment reassembly -- error paths */
     RUN(fragment_invalid_total_frags);


### PR DESCRIPTION
## Summary

Closes #46.

`parse_file_tree()` in `src/protocol/handshake.c` recursively descends into client-supplied subdirectory trees with no depth bound. A crafted 2 KB checksum response (e.g. 300 nesting levels × ~7 bytes each) could exhaust the call stack and crash the server.

Real BC directory trees are 3-4 levels deep. This PR adds a generous limit of **16 levels** and rejects anything deeper with a `LOG_WARN`.

## Changes

| File | What changed |
|------|-------------|
| `src/protocol/handshake.c` | Added `#define BC_MAX_TREE_DEPTH 16`; added `int depth` parameter to `parse_file_tree()`; depth guard at function entry; both recursive call sites now pass `depth + 1`; top-level call site passes `0` |
| `tests/test_protocol.c` | New test `checksum_resp_parse_depth_limit`: builds an 18-level crafted payload (beyond the 16-level limit) and asserts that `bc_checksum_response_parse()` returns `false` |

## Implementation notes

- `BC_MAX_TREE_DEPTH` is defined at the top of `handshake.c` (file-local — it's only used by the parser and doesn't need to be in a header).
- The guard fires at `depth > 16`, so a tree exactly 16 levels deep still parses successfully (consistent with real BC data and the issue spec).
- Zero new warnings with `-Wall -Wextra -Wpedantic` on both native GCC and MinGW cross-compile.

## Test plan

- [x] `make all` — zero warnings
- [x] `make test` — all 10 deterministic suites pass (`test_protocol` includes the new regression)
- [x] `test_battle` flaky failure is a pre-existing port 6500 bind-conflict race (tracked separately, unrelated to this PR)
- [x] New test `checksum_resp_parse_depth_limit` explicitly verifies the 18-level deep payload is rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)