### PR TITLE
fix: raise BC_MAX_PLAYERS from 7 to 9 (stock slot count)

### DIFF
--- a/include/openbc/gamespy.h
+++ b/include/openbc/gamespy.h
@@ -3,6 +3,7 @@
 
 #include "openbc/types.h"
 #include "openbc/net.h"
+#include "openbc/opcodes.h"
 
 /*
  * GameSpy query/response handler (QR1 protocol).
@@ -43,8 +44,9 @@ typedef struct {
     int  timelimit;            /* Minutes, 0 = no limit */
     int  fraglimit;            /* Kills, 0 = no limit */
     /* Player list for GameSpy \player_N\ entries.
-     * player_names[0] = "Dedicated Server" (always present). */
-    char player_names[8][32];
+     * player_names[0] = "Dedicated Server" (always present).
+     * Sized to BC_MAX_PLAYERS so every peer slot has a name entry. */
+    char player_names[BC_MAX_PLAYERS][32];
     int  player_count;         /* Number of entries in player_names[] */
 } bc_server_info_t;
 

--- a/include/openbc/opcodes.h
+++ b/include/openbc/opcodes.h
@@ -149,8 +149,9 @@
 /* === Connection Constants === */
 #define BC_DEFAULT_PORT            0x5655  /* 22101 decimal */
 #define BC_GAMESPY_PORT            0x5656  /* 22102 decimal */
-/* Peer array size: slot 0 = dedicated server, slots 1-6 = up to 6 human players */
-#define BC_MAX_PLAYERS             7
+/* Peer array size: slot 0 = dedicated server, slots 1-8 = up to 8 human players.
+ * Stock BC supports 8 human slots; MissionInit totalSlots = BC_MAX_PLAYERS = 9. */
+#define BC_MAX_PLAYERS             9
 
 /* Opcode name lookup (returns static string, NULL for unknown) */
 const char *bc_opcode_name(int opcode);

--- a/src/network/gamespy.c
+++ b/src/network/gamespy.c
@@ -146,7 +146,7 @@ int bc_gamespy_build_response(u8 *out, int out_size,
 
     /* Append \player_N\ entries (stock order: after rules, before \final\).
      * Stock trace: \player_0\Dedicated Server\final\ */
-    for (int i = 0; i < info->player_count && i < 8; i++) {
+    for (int i = 0; i < info->player_count && i < BC_MAX_PLAYERS; i++) {
         int added = snprintf((char *)out + written,
                               (size_t)(out_size - written),
                               "\\player_%d\\%s", i, info->player_names[i]);

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -54,7 +54,7 @@ void bc_handle_gamespy(bc_socket_t *sock, const bc_addr_t *from,
     /* Rebuild player list: player_0 = "Dedicated Server" (always),
      * then one entry per connected human player. */
     g_info.player_count = 1;  /* slot 0 = dedi, already set at init */
-    for (int i = 1; i < BC_MAX_PLAYERS && g_info.player_count < 8; i++) {
+    for (int i = 1; i < BC_MAX_PLAYERS && g_info.player_count < BC_MAX_PLAYERS; i++) {
         if (g_peers.peers[i].state != PEER_EMPTY) {
             snprintf(g_info.player_names[g_info.player_count],
                      sizeof(g_info.player_names[0]),

--- a/src/server/server_handshake.c
+++ b/src/server/server_handshake.c
@@ -293,7 +293,7 @@ static void send_settings_and_gameinit(int peer_slot)
  *
  * The ring buffer holds the last BC_CONNECT_RATE_SLOTS disconnected IPs.
  * With 16 slots and a 2-second window this comfortably covers every
- * realistic scenario (BC_MAX_PLAYERS is 7).
+ * realistic scenario (BC_MAX_PLAYERS is 9).
  * ---------------------------------------------------------------------------
  */
 #define BC_CONNECT_RATE_LIMIT_MS  2000  /* 2-second cooldown after disconnect */

--- a/tests/test_gamespy.c
+++ b/tests/test_gamespy.c
@@ -365,6 +365,38 @@ TEST(build_validate_deterministic)
     ASSERT(memcmp(buf1, buf2, (size_t)len1) == 0);
 }
 
+/* Verify player_names[] array is large enough for all peer slots and that
+ * the response builder emits every entry without overflow. */
+TEST(player_names_covers_all_slots)
+{
+    bc_server_info_t info;
+    gs_test_info(&info, "SlotTest", "DM", BC_MAX_PLAYERS - 1, BC_MAX_PLAYERS - 1);
+
+    /* Fill every slot: index 0 = dedi, indices 1..(BC_MAX_PLAYERS-1) = humans */
+    snprintf(info.player_names[0], sizeof(info.player_names[0]),
+             "Dedicated Server");
+    for (int i = 1; i < BC_MAX_PLAYERS; i++) {
+        snprintf(info.player_names[i], sizeof(info.player_names[i]),
+                 "Player%d", i);
+    }
+    info.player_count = BC_MAX_PLAYERS;
+
+    u8 buf[2048];
+    const u8 query[] = "\\status\\";
+    int len = bc_gamespy_build_response(buf, sizeof(buf), &info,
+                                        query, (int)sizeof(query) - 1);
+    ASSERT(len > 0);
+
+    /* Every player entry must appear in the response */
+    ASSERT(gs_has_value((char *)buf, len, "player_0", "Dedicated Server"));
+    for (int i = 1; i < BC_MAX_PLAYERS; i++) {
+        char key[16], val[16];
+        snprintf(key, sizeof(key), "player_%d", i);
+        snprintf(val, sizeof(val), "Player%d", i);
+        ASSERT(gs_has_value((char *)buf, len, key, val));
+    }
+}
+
 /* ======================================================================
  * Integration tests: server responds to GameSpy queries
  * ====================================================================== */
@@ -904,6 +936,7 @@ TEST_MAIN_BEGIN()
     RUN(gsmsalg_empty_challenge);
     RUN(build_validate_response);
     RUN(build_validate_deterministic);
+    RUN(player_names_covers_all_slots);
 
     /* Integration tests */
     RUN(server_responds_to_lan_query);


### PR DESCRIPTION
## Summary

Raises `BC_MAX_PLAYERS` from 7 to 9 to match stock Bridge Commander's actual peer slot count (8 human players + 1 dedicated server ghost).

This was extracted from PR #52 (fire rate limiting) per the review in #67, which flagged it as a fundamental constant change that needs its own dedicated review.

## Changes (6 files, +43/-7)

| File | Change |
|------|--------|
| `include/openbc/opcodes.h` | `BC_MAX_PLAYERS` 7 → 9, updated comment |
| `include/openbc/gamespy.h` | `player_names[8]` → `player_names[BC_MAX_PLAYERS]` (derived from constant) |
| `src/network/gamespy.c` | Player list loop cap `< 8` → `< BC_MAX_PLAYERS` |
| `src/server/server_dispatch.c` | GameSpy player list cap `< 8` → `< BC_MAX_PLAYERS` |
| `src/server/server_handshake.c` | Rate limiter comment: "BC_MAX_PLAYERS is 7" → "is 9" |
| `tests/test_gamespy.c` | New test: `player_names_covers_all_slots` |

## Downstream Impact Audit

All of these are **already parameterized on `BC_MAX_PLAYERS`** and auto-adjust:

- **Peer arrays**: `bc_peer_t peers[BC_MAX_PLAYERS]` — grows from 7 to 9 entries
- **Score/kill/death/team arrays**: `g_player_scores[BC_MAX_PLAYERS]` etc. — grow to 9
- **Damage ledger**: `g_damage_ledger[BC_MAX_PLAYERS][BC_MAX_PLAYERS]` — 49→81 entries
- **Reconnect scores**: `g_reconnect_scores[BC_MAX_PLAYERS]` — grows to 9
- **Loop bounds**: All `for (i = 1; i < BC_MAX_PLAYERS; ...)` loops in `main.c`, `peer.c`, `server_send.c`, `server_handshake.c`, `server_dispatch.c` — automatically iterate 2 more slots
- **Bounds checks**: All `slot >= BC_MAX_PLAYERS` guards — automatically accept slots 7-8
- **Player ID validation**: `player_ids.h` range — expands to cover slots 7-8
- **MissionInit totalSlots**: `bc_mission_init_total_slots()` → now returns 9 (8 human + 1 dedi)
- **Rate limiter ring buffer**: 16 slots, already `>= BC_MAX_PLAYERS` at either 7 or 9

## What was NOT touched (hardcoded values that are correct at both 7 and 9)

- `bc_mission_init_total_slots()` caps `human_slots > 8` — correct (8 = BC_MAX_PLAYERS - 1)
- `--max` CLI flag clamps to `BC_MAX_PLAYERS` — correct (auto-adjusts)
- `BC_CONNECT_RATE_SLOTS = 16` — already ≥ 9

## Test plan

- [x] `make all` — zero warnings with `-Wall -Wextra -Wpedantic`
- [x] `make test` — 16/16 test suites pass, 0 failures
- [x] New test `player_names_covers_all_slots` validates all 9 slots appear in GameSpy response
- [x] `test_battle` `full_join_flow_multi_client` verifies MissionInit `totalSlots = 9`
- [x] `test_self_destruct` verifies MissionInit byte matches `BC_MAX_PLAYERS`
- [x] `test_player_ids` boundary tests auto-adjust to new constant

Refs #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)