### PR TITLE
Fix MissionInit playerLimit off-by-one (0x07 -> 0x08)

### DIFF
--- a/include/openbc/opcodes.h
+++ b/include/openbc/opcodes.h
@@ -149,9 +149,10 @@
 /* === Connection Constants === */
 #define BC_DEFAULT_PORT            0x5655  /* 22101 decimal */
 #define BC_GAMESPY_PORT            0x5656  /* 22102 decimal */
-/* Peer array size: slot 0 = dedicated server, slots 1-8 = up to 8 human players.
- * Stock BC supports 8 human slots; MissionInit totalSlots = BC_MAX_PLAYERS = 9. */
+/* Peer array size: slot 0 = dedicated server, slots 1-8 = up to 8 human players. */
 #define BC_MAX_PLAYERS             9
+/* Stock MissionInit (0x35) reports playerLimit as max human players (0x08). */
+#define BC_MISSION_INIT_PLAYER_LIMIT 8
 
 /* Opcode name lookup (returns static string, NULL for unknown) */
 const char *bc_opcode_name(int opcode);

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -100,14 +100,11 @@ void bc_handle_gamespy(bc_socket_t *sock, const bc_addr_t *from,
 /* Stock BC ship-death OBJECT_EXPLODING event visual lifetime. */
 static const f32 BC_SHIP_DEATH_EXPLODING_EVENT_LIFETIME_SEC = 9.5f;
 
-/* MissionInit byte[1] is total slots, including dedicated ghost slot 0.
- * GameSpy maxplayers excludes that slot, so MissionInit = GameSpy + 1. */
+/* Stock BC emits a fixed MissionInit playerLimit byte (0x08).
+ * This value is protocol-facing and does not mirror GameSpy maxplayers. */
 static int bc_mission_init_total_slots(void)
 {
-    int human_slots = g_info.maxplayers;
-    if (human_slots < 1) human_slots = 1;
-    if (human_slots > 8) human_slots = 8;
-    return human_slots + 1;
+    return BC_MISSION_INIT_PLAYER_LIMIT;
 }
 
 /* Return a player's name for log output. Falls back to "slot N" if unnamed. */
@@ -1325,7 +1322,7 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
         bc_relay_to_others(peer_slot, payload, payload_len, true);
         /* Respond with MissionInit (0x35) -- tells client which star system
          * to load and what the match rules are.
-         * Byte[1] is total slots (human slots + dedicated ghost slot 0). */
+         * Byte[1] is stock's fixed player-limit byte (0x08). */
         u8 mi[32];
         i32 end_time = (g_round_end_time >= 0.0f) ? (i32)g_round_end_time : 0;
         int total_slots = bc_mission_init_total_slots();

--- a/tests/test_battle.c
+++ b/tests/test_battle.c
@@ -785,9 +785,8 @@ TEST(full_join_flow_multi_client)
             }
 
             CHECK(got_mission);
-            /* MissionInit byte[1] should match server slot limit
-             * (including dedicated ghost slot 0). */
-            CHECK_EQ(mission_total_slots, BC_MAX_PLAYERS);
+            /* Stock MissionInit advertises a fixed player limit byte (0x08). */
+            CHECK_EQ(mission_total_slots, BC_MISSION_INIT_PLAYER_LIMIT);
         }
 
         cl->connected = true;

--- a/tests/test_self_destruct.c
+++ b/tests/test_self_destruct.c
@@ -386,7 +386,7 @@ TEST(mission_init_total_slots_matches_server_limit)
                                                   &msg_len, 2000);
         CHECK(msg != NULL);
         CHECK(msg_len >= 2);
-        CHECK(msg[1] == BC_MAX_PLAYERS); /* human slots + dedicated slot 0 */
+        CHECK(msg[1] == BC_MISSION_INIT_PLAYER_LIMIT);
     }
 
 cleanup:


### PR DESCRIPTION
## Summary
- Fix MissionInit (0x35) `playerLimit` byte to match stock protocol output (`0x08`).
- Stop deriving MissionInit `playerLimit` from GameSpy `maxplayers`.
- Add an explicit protocol constant for stock MissionInit limit to prevent future regressions.
- Update integration assertions that previously expected `0x07`.

## Why
Issue #62 reports an off-by-one mismatch:
- Stock: `35 08 01 FF FF`
- OpenBC: `35 07 01 FF FF`

OpenBC was computing MissionInit slots from `g_info.maxplayers + 1`. With current server limits this resolved to `7`, not the stock-observed `8`.

## Changes
- `include/openbc/opcodes.h`
  - Added `BC_MISSION_INIT_PLAYER_LIMIT` (`8`) for stock protocol value.
- `src/server/server_dispatch.c`
  - `bc_mission_init_total_slots()` now returns `BC_MISSION_INIT_PLAYER_LIMIT`.
  - Updated MissionInit comments to document fixed stock behavior.
- `tests/test_battle.c`
  - Updated MissionInit assertion to expect `BC_MISSION_INIT_PLAYER_LIMIT`.
- `tests/test_self_destruct.c`
  - Updated MissionInit assertion to expect `BC_MISSION_INIT_PLAYER_LIMIT`.

## Validation
Ran locally in this branch:
- `./build/tests/test_protocol` (pass)
- `./build/tests/test_battle` (pass)
- `./build/tests/test_self_destruct` (pass)

Closes #62
