### PR TITLE
fix: do not send Explosion (0x29) for collision-induced kills

### DIFF
--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -1679,22 +1679,11 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
                                 bc_send_to_all(expl, elen, true);
                         }
 
-                        /* Send Explosion (0x29) -- visual kill effect.
-                         * Stock BC does NOT send DestroyObject (0x14) for
-                         * ship deaths. The old ship is implicitly replaced
-                         * when the respawn ObjCreateTeam arrives. */
-                        {
-                            u8 boom[16];
-                            int blen = bc_build_explosion(
-                                boom, sizeof(boom),
-                                target->ship.object_id,
-                                target->ship.pos.x,
-                                target->ship.pos.y,
-                                target->ship.pos.z,
-                                dmg, collision_radius);
-                            if (blen > 0)
-                                bc_send_to_all(boom, blen, true);
-                        }
+                        /* No Explosion (0x29) for collision kills.
+                         * Stock BC only sends ObjectExplodingEvent for
+                         * collision-induced deaths; Explosion is reserved
+                         * for weapon kills (beam/torpedo).  See issue #60. */
+
                         /* Disable server auto-respawn; respawn is client-driven. */
                         target->has_ship = false;
                         target->respawn_timer = 0.0f;
@@ -1819,21 +1808,9 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
                                     bc_send_to_all(expl2, elen2, true);
                             }
 
-                            /* Send Explosion (0x29) -- visual kill effect.
-                             * Stock BC does NOT send DestroyObject (0x14)
-                             * for ship deaths. */
-                            {
-                                u8 boom2[16];
-                                int blen2 = bc_build_explosion(
-                                    boom2, sizeof(boom2),
-                                    source->ship.object_id,
-                                    source->ship.pos.x,
-                                    source->ship.pos.y,
-                                    source->ship.pos.z,
-                                    sdmg, src_coll_radius);
-                                if (blen2 > 0)
-                                    bc_send_to_all(boom2, blen2, true);
-                            }
+                            /* No Explosion (0x29) for collision kills.
+                             * See target-side comment above (issue #60). */
+
                             /* Disable server auto-respawn; respawn is client-driven. */
                             source->has_ship = false;
                             source->respawn_timer = 0.0f;

--- a/tests/test_self_destruct.c
+++ b/tests/test_self_destruct.c
@@ -277,6 +277,7 @@ TEST(collision_death_no_auto_respawn_and_repair_events_bounded)
     bool got_score_change = false;
     bool saw_destroy_obj = false;
     bool saw_server_respawn = false;
+    bool saw_explosion_0x29 = false;
     int add_to_repair_events = 0;
     const i32 ship_id = bc_make_ship_id(0);
 
@@ -297,6 +298,11 @@ TEST(collision_death_no_auto_respawn_and_repair_events_bounded)
         }
         if (msg[0] == BC_MSG_SCORE_CHANGE) {
             got_score_change = true;
+            continue;
+        }
+        /* Issue #60: collision kills must NOT produce Explosion (0x29). */
+        if (msg[0] == BC_OP_EXPLOSION) {
+            saw_explosion_0x29 = true;
             continue;
         }
         if (msg[0] == BC_OP_PYTHON_EVENT && msg_len >= 17) {
@@ -325,6 +331,7 @@ TEST(collision_death_no_auto_respawn_and_repair_events_bounded)
     CHECK(got_score_change);
     CHECK(!saw_destroy_obj);
     CHECK(!saw_server_respawn);
+    CHECK(!saw_explosion_0x29);
     /* Death repair burst (issue #61) raises the upper bound. */
     CHECK(add_to_repair_events <= 30);
 


### PR DESCRIPTION
## Summary

- Remove Explosion (0x29) from **both** collision death handlers (target ship and source ship) in `server_dispatch.c`
- Stock BC only sends `ObjectExplodingEvent` (0x06, factory 0x8129) for collision-induced deaths; `Explosion` (0x29) is reserved for weapon kills (beam/torpedo)
- OpenBC was incorrectly sending both, which could cause a double-explosion visual on the client

## Changes

### `src/server/server_dispatch.c`
- **Target ship collision death** (~line 1637): Removed the `bc_build_explosion()` block that sent Explosion (0x29) after a collision kill
- **Source ship collision death** (~line 1774): Removed the matching `bc_build_explosion()` block for the source ship in ship-vs-ship collisions
- Added clear comments explaining that Explosion is only for weapon kills (issue #60)

### `tests/test_self_destruct.c`
- Added `saw_explosion_0x29` flag to the `collision_death_no_auto_respawn_and_repair_events_bounded` test
- Checks for `BC_OP_EXPLOSION` (0x29) in the message loop
- Asserts `!saw_explosion_0x29` — verifying no Explosion opcode is received during a collision kill

## Test plan

- [x] `make all` builds with zero warnings (`-Wall -Wextra -Wpedantic`)
- [x] `test_self_destruct` passes all 3 tests including the new `!saw_explosion_0x29` assertion
- [x] Full test suite (16 suites) passes
- [x] Weapon kill paths (beam/torpedo) are unaffected — they still send Explosion (0x29) as before

## References

- Closes #60
- [docs/game-systems/ship-death-lifecycle.md](docs/game-systems/ship-death-lifecycle.md) — documents that Explosion is NOT sent for collision kills (line 54)

🤖 Generated with [Claude Code](https://claude.com/claude-code)