### PR TITLE
feat: send per-subsystem ADD_TO_REPAIR_LIST on collision death

### DIFF
--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -324,6 +324,34 @@ static void generate_damage_events(int target_slot,
     }
 }
 
+
+/* On collision death, stock BC sends ADD_TO_REPAIR_LIST for every subsystem
+ * whose condition is below maximum -- no bucket limiting.  This ensures the
+ * client's repair queue reflects all damaged subsystems at death time.
+ * bc_repair_add() deduplicates against subsystems already queued by
+ * generate_damage_events(), so only genuinely new entries get a network event. */
+static void generate_death_repair_events(int target_slot,
+                                          const bc_ship_class_t *cls)
+{
+    bc_peer_t *target = &g_peers.peers[target_slot];
+    bc_ship_state_t *ship = &target->ship;
+
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (ship->subsystem_hp[i] < cls->subsystems[i].max_condition) {
+            /* Try to add to repair queue -- false if already queued */
+            if (bc_repair_add(ship, (u8)i)) {
+                u8 evt[17];
+                int len = bc_build_python_subsystem_event(
+                    evt, sizeof(evt),
+                    BC_EVENT_ADD_TO_REPAIR,
+                    ship->subsys_obj_id[i],
+                    ship->repair_subsys_obj_id);
+                if (len > 0) bc_send_to_all(evt, len, true);
+            }
+        }
+    }
+}
+
 static f32 total_shields(const bc_ship_state_t *ship)
 {
     f32 sum = 0.0f;
@@ -1620,6 +1648,11 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
                              object_owner_name(cev.source_object_id));
 
                     if (!target->ship.alive) {
+                        /* Death repair burst: stock sends ADD_TO_REPAIR_LIST
+                         * for every damaged subsystem at death (issue #61).
+                         * Must precede OBJECT_EXPLODING to match stock order. */
+                        generate_death_repair_events(target_slot, tcls);
+
                         /* Send OBJECT_EXPLODING PythonEvent */
                         {
                             i32 killer_id = 0;
@@ -1758,6 +1791,9 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
                                  peer_name(src_slot), sdmg);
 
                         if (!source->ship.alive) {
+                            /* Death repair burst (issue #61) */
+                            generate_death_repair_events(src_slot, scls);
+
                             /* Send OBJECT_EXPLODING PythonEvent */
                             {
                                 i32 killer_id = 0;

--- a/tests/test_death_repair_burst.c
+++ b/tests/test_death_repair_burst.c
@@ -1,0 +1,191 @@
+/* Issue #61: death repair burst unit tests.
+ * Verifies that collision death sends ADD_TO_REPAIR_LIST for all damaged
+ * subsystems without bucket limiting, and that bc_repair_add() deduplication
+ * prevents double-sends for subsystems already queued. */
+
+#include "test_util.h"
+#include "openbc/ship_data.h"
+#include "openbc/ship_state.h"
+#include "openbc/combat.h"
+#include "openbc/game_builders.h"
+#include <string.h>
+
+#define REGISTRY_DIR "data/vanilla-1.1"
+
+static bc_game_registry_t g_reg;
+
+TEST(load_registry)
+{
+    memset(&g_reg, 0, sizeof(g_reg));
+    ASSERT(bc_registry_load_dir(&g_reg, REGISTRY_DIR));
+    ASSERT(g_reg.ship_count > 0);
+}
+
+/* Death burst covers all damaged subsystems, not just bucket-limited ones.
+ * Pre-damage 10 subsystems, queue 3 (simulating bucket limiting), then
+ * verify the death burst picks up the remaining 7. */
+TEST(death_burst_covers_all_damaged)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3); /* Galaxy */
+    ASSERT(cls != NULL);
+    ASSERT(cls->subsystem_count > 10);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    /* Pre-damage 10 subsystems to below max_condition. */
+    int damaged_count = 0;
+    for (int i = 0; i < cls->subsystem_count && damaged_count < 10; i++) {
+        if (cls->subsystems[i].max_condition > 0.0f) {
+            ship.subsystem_hp[i] = cls->subsystems[i].max_condition * 0.5f;
+            damaged_count++;
+        }
+    }
+    ASSERT(damaged_count == 10);
+
+    /* Simulate bucket-limited generate_damage_events: queue only 3. */
+    int pre_queued = 0;
+    for (int i = 0; i < cls->subsystem_count && pre_queued < 3; i++) {
+        if (ship.subsystem_hp[i] < cls->subsystems[i].max_condition) {
+            ASSERT(bc_repair_add(&ship, (u8)i));
+            pre_queued++;
+        }
+    }
+    ASSERT_EQ(ship.repair_count, 3);
+
+    /* Death burst: iterate all subsystems, add damaged ones to repair queue.
+     * This mimics the generate_death_repair_events() logic. */
+    int death_burst_events = 0;
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (ship.subsystem_hp[i] < cls->subsystems[i].max_condition) {
+            if (bc_repair_add(&ship, (u8)i)) {
+                death_burst_events++;
+            }
+        }
+    }
+
+    /* 10 damaged - 3 pre-queued = 7 new events from death burst */
+    ASSERT_EQ(death_burst_events, 7);
+    ASSERT_EQ(ship.repair_count, 10);
+}
+
+/* When all damaged subsystems are already queued, the death burst should
+ * produce zero additional events (deduplication). */
+TEST(death_burst_deduplicates)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    /* Damage all subsystems */
+    int total_damaged = 0;
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (cls->subsystems[i].max_condition > 0.0f) {
+            ship.subsystem_hp[i] = cls->subsystems[i].max_condition * 0.3f;
+            total_damaged++;
+        }
+    }
+    ASSERT(total_damaged > 0);
+
+    /* Queue ALL damaged subsystems (simulating pre-death events covered all) */
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (ship.subsystem_hp[i] < cls->subsystems[i].max_condition)
+            bc_repair_add(&ship, (u8)i);
+    }
+    ASSERT_EQ(ship.repair_count, total_damaged);
+
+    /* Death burst should produce zero new events */
+    int death_burst_events = 0;
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (ship.subsystem_hp[i] < cls->subsystems[i].max_condition) {
+            if (bc_repair_add(&ship, (u8)i))
+                death_burst_events++;
+        }
+    }
+    ASSERT_EQ(death_burst_events, 0);
+    ASSERT_EQ(ship.repair_count, total_damaged);
+}
+
+/* Subsystem at full HP should NOT generate an event in the death burst. */
+TEST(death_burst_skips_undamaged)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    /* Damage only 2 subsystems */
+    if (cls->subsystem_count >= 2) {
+        ship.subsystem_hp[0] = cls->subsystems[0].max_condition * 0.5f;
+        ship.subsystem_hp[1] = cls->subsystems[1].max_condition * 0.5f;
+    }
+
+    /* Death burst should only produce 2 events */
+    int death_burst_events = 0;
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (ship.subsystem_hp[i] < cls->subsystems[i].max_condition) {
+            if (bc_repair_add(&ship, (u8)i))
+                death_burst_events++;
+        }
+    }
+    ASSERT_EQ(death_burst_events, 2);
+    ASSERT_EQ(ship.repair_count, 2);
+}
+
+/* Each subsystem event should reference a valid object ID from the
+ * player's allocation range. */
+TEST(death_burst_uses_valid_subsystem_ids)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    /* Damage all subsystems */
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (cls->subsystems[i].max_condition > 0.0f)
+            ship.subsystem_hp[i] = cls->subsystems[i].max_condition * 0.5f;
+    }
+
+    /* Verify all subsystem IDs are in slot 0's range */
+    i32 slot0_base = bc_make_object_id(0, 0);
+    i32 slot0_end = bc_make_object_id(1, 0);
+
+    for (int i = 0; i < cls->subsystem_count && i < BC_MAX_SUBSYSTEMS; i++) {
+        if (ship.subsystem_hp[i] < cls->subsystems[i].max_condition) {
+            i32 sid = ship.subsys_obj_id[i];
+            ASSERT(sid >= slot0_base);
+            ASSERT(sid < slot0_end);
+        }
+    }
+
+    /* Verify repair subsystem ID is also in range */
+    ASSERT(ship.repair_subsys_obj_id >= slot0_base);
+    ASSERT(ship.repair_subsys_obj_id < slot0_end);
+
+    /* Build an actual event and verify wire format */
+    u8 evt[17];
+    int len = bc_build_python_subsystem_event(
+        evt, sizeof(evt),
+        BC_EVENT_ADD_TO_REPAIR,
+        ship.subsys_obj_id[0],
+        ship.repair_subsys_obj_id);
+    ASSERT_EQ(len, 17);
+    ASSERT_EQ(evt[0], 0x06); /* PythonEvent opcode */
+}
+
+TEST_MAIN_BEGIN()
+    RUN(load_registry);
+    RUN(death_burst_covers_all_damaged);
+    RUN(death_burst_deduplicates);
+    RUN(death_burst_skips_undamaged);
+    RUN(death_burst_uses_valid_subsystem_ids);
+TEST_MAIN_END()

--- a/tests/test_self_destruct.c
+++ b/tests/test_self_destruct.c
@@ -325,7 +325,8 @@ TEST(collision_death_no_auto_respawn_and_repair_events_bounded)
     CHECK(got_score_change);
     CHECK(!saw_destroy_obj);
     CHECK(!saw_server_respawn);
-    CHECK(add_to_repair_events <= 6);
+    /* Death repair burst (issue #61) raises the upper bound. */
+    CHECK(add_to_repair_events <= 30);
 
 cleanup:
     if (cli_ok) test_client_disconnect(&cli);


### PR DESCRIPTION
## Summary

Resolves #61 — Stock BC sends `ADD_TO_REPAIR_LIST` PythonEvents for **every** damaged subsystem when a ship dies to collision damage (~13 for a Galaxy-class). OpenBC previously sent only 3–5 due to bucket limiting in `generate_damage_events()`.

### Changes

- **`src/server/server_dispatch.c`**: Added `generate_death_repair_events()` — iterates all subsystems and emits `ADD_TO_REPAIR_LIST` for each with HP below `max_condition`, with no bucket limiting. `bc_repair_add()` deduplication prevents double-sends for subsystems already queued by the bucket-limited damage path. Called at both collision death sites (target ship death and source ship death) **before** `OBJECT_EXPLODING` to match stock event ordering.

- **`tests/test_self_destruct.c`**: Raised collision death test's `add_to_repair_events` upper bound from `<= 6` to `<= 30` to accommodate the full per-subsystem burst. Self-destruct test bound unchanged (self-destruct path doesn't use death burst).

- **`tests/test_death_repair_burst.c`** (new): 5 unit tests validating death burst logic:
  1. Death burst covers all damaged subsystems beyond bucket-limited ones
  2. Deduplication produces zero events when all subsystems already queued
  3. Undamaged subsystems are skipped
  4. Subsystem object IDs are in the player's allocation range
  5. Wire format verification of built events

## Test plan

- [x] `make all` builds with zero warnings (`-Wall -Wextra -Wpedantic`)
- [x] All 17 test suites pass (including new `test_death_repair_burst`)
- [ ] Manual verification with stock BC client: collision death shows full repair queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)