### PR TITLE
docs: event-forward wire format and weapon-kill scoring anomaly

### DIFF
--- a/docs/bugs/bug-reports/20260222-weapon-kill-score-anomaly.md
+++ b/docs/bugs/bug-reports/20260222-weapon-kill-score-anomaly.md
@@ -1,0 +1,88 @@
+# Bug Report: SCORE_CHANGE Not Sent for Weapon Kills (Stock Dedi Anomaly)
+
+**Date**: 2026-02-22
+**Severity**: MEDIUM
+**Status**: OPEN
+**Affects**: Stock BC 1.1 dedicated server (confirmed anomaly)
+**OpenBC action**: Send SCORE_CHANGE for ALL death types (improve on stock)
+
+---
+
+## Summary
+
+The stock Bridge Commander dedicated server does not send SCORE_CHANGE (0x36) messages
+when a ship is destroyed by weapon fire (phasers, torpedoes). It DOES correctly send
+SCORE_CHANGE for collision kills and self-destructs. This means clients never receive
+score updates for the most common kill type in multiplayer — weapon kills.
+
+---
+
+## Evidence
+
+### Battle of Valentine's Day Trace (2026-02-14)
+
+- **Duration**: 33.5 minutes
+- **Players**: 3
+- **Total ship deaths**: 59
+- **Weapon kills**: 55
+- **Self-destructs**: 4
+- **SCORE_CHANGE messages**: **0** (zero)
+
+### Collision Test Trace (same session)
+
+- **Duration**: 28 seconds
+- **Players**: 2
+- **Total ship deaths**: 1 (collision kill)
+- **SCORE_CHANGE messages**: **1** (correct)
+
+### Self-Destruct Trace (earlier verification, 2026-02-21)
+
+- Self-destruct deaths correctly produce SCORE_CHANGE with death counted and no kill credit
+
+### Summary Table
+
+| Kill Type | Deaths Observed | SCORE_CHANGE Sent | Correct? |
+|-----------|----------------|-------------------|----------|
+| Weapon (beam/torpedo) | 55 | 0 | **NO** |
+| Self-destruct | 4 | 4 | YES |
+| Collision | 1 | 1 | YES |
+
+---
+
+## Root Cause Analysis
+
+The ObjectKilledHandler (Python mission script) is responsible for computing scores and
+broadcasting SCORE_CHANGE. It runs when the OBJECT_EXPLODING event fires on the host.
+
+For collision kills and self-destructs, the damage pipeline runs entirely on the host,
+which triggers OBJECT_EXPLODING locally and the ObjectKilledHandler fires.
+
+For weapon kills, the damage pipeline runs on each **receiving client** independently
+(receiver-local hit detection). The host may not process the weapon hit damage at all,
+so OBJECT_EXPLODING may never fire on the host. The Explosion (0x29) message IS sent
+(59 observed), but this appears to be triggered by a different code path that doesn't
+invoke the Python scoring handler.
+
+---
+
+## Recommendation for OpenBC
+
+OpenBC should send SCORE_CHANGE for **ALL death types**, regardless of the damage source:
+
+1. **Weapon kills**: When the server detects a ship death (hull HP reaches zero), compute
+   scores from the damage ledger and broadcast SCORE_CHANGE
+2. **Collision kills**: Already working (verified in collision test trace)
+3. **Self-destructs**: Already working (verified in self-destruct trace)
+4. **Explosion damage**: Same as weapon kills
+
+This is an intentional improvement over stock behavior. The scoring system exists and
+works correctly — it's only the triggering path that's broken for weapon kills on the
+stock dedicated server.
+
+---
+
+## Related
+
+- [gamemode-system.md](../../planning/gamemode-system.md) — Scoring system spec (contains anomaly note)
+- [ship-death-lifecycle.md](../../game-systems/ship-death-lifecycle.md) — Ship death sequence
+- [server-authority.md](../../architecture/server-authority.md) — Scoring is server-authoritative

--- a/docs/game-systems/ship-death-lifecycle.md
+++ b/docs/game-systems/ship-death-lifecycle.md
@@ -8,11 +8,7 @@ Behavioral specification for how ships are destroyed and respawned in Bridge Com
 
 ## Overview
 
-When a ship is destroyed in multiplayer, the server broadcasts an explosion event to all
-clients. The server does **not** auto-respawn the player — instead, the client returns to
-the ship selection screen and sends ObjCreateTeam (0x03) when the player picks a new ship.
-The protocol includes a "destroy object" message type, but it is **not used** for
-multiplayer ship death in stock behavior.
+When a ship is destroyed in multiplayer, the server broadcasts an explosion event to all clients and then immediately creates a new ship object for the same player (respawn). The protocol includes a "destroy object" message type, but it is **not used** for multiplayer ship death in stock behavior.
 
 ---
 
@@ -28,38 +24,24 @@ The messages sent depend on whether this is a **combat kill** or a **self-destru
 
 #### Combat Kill (weapon, collision, or explosion damage)
 
-The server sends these messages to all clients:
+The server sends three messages to all clients:
 
 **a) PythonEvent (opcode 0x06) — ObjectExplodingEvent**:
 - Factory ID: 0x8129
 - Event type: OBJECT_EXPLODING (0x0080004E)
-- Contains: dying ship's object ID, killer's player ID, explosion lifetime
-- source = killer's ship object ID (or NULL for environment kills)
+- Contains: dying ship's object ID, killer's player ID, explosion lifetime (9.5 seconds)
+- source = killer's ship object ID
 - dest = dying ship's object ID
 - Sent reliably to the "NoMe" routing group
 
-**b) ~13 TGSubsystemEvent (factory 0x0101) — ADD_TO_REPAIR_LIST**:
-- One per damaged subsystem at the moment of death
-- Event code: 0x800000DF
-- source = damaged subsystem's TGObject ID (must be in the player's object ID range)
-- dest = ship's RepairSubsystem TGObject ID
-- Count varies by collision geometry (12-14 confirmed from traces)
-
-**c) SCORE_CHANGE (0x36)**:
-- Kill/death credit as appropriate
-
-**d) Explosion (opcode 0x29)** — for **weapon kills only**:
+**b) Explosion (opcode 0x29)**:
 - Contains: dying ship's object ID, impact position (compressed), damage amount, explosion radius
 - Triggers client-side visual effects
-- **NOT sent for collision-induced kills** — only ObjectExplodingEvent triggers the animation
 
-The server does **NOT** auto-respawn after combat kills. After the explosion animation,
-the client returns to the ship selection screen and sends ObjCreateTeam (0x03) when the
-player picks a new ship.
-
-> **Note**: Whether Explosion (0x29) is sent depends on the kill source. Stock traces
-> confirm: collision kills = no Explosion; weapon kills = Explosion sent. Self-destruct =
-> no Explosion. This distinction needs further weapon kill trace verification.
+**c) ObjCreateTeam (opcode 0x03) — Auto-Respawn**:
+- Server immediately creates a new ship object for the same player
+- Contains: owner player slot, team assignment, full serialized ship data
+- The new ship has fresh subsystems at full health
 
 #### Self-Destruct (opcode 0x13)
 
@@ -82,14 +64,14 @@ The server sends **only** the ObjectExplodingEvent:
 
 ### 3. Respawn
 
-Respawn behavior is the same for all death types (combat kill, self-destruct, collision):
+Respawn behavior differs by death type:
 
-After the explosion animation, the client returns to the ship selection screen.
-The **client** sends ObjCreateTeam (0x03) when the player picks a new ship. The server
-relays this to all other clients via star topology.
+**Combat kill**: The server auto-respawns the player immediately by sending ObjCreateTeam
+(0x03) with the same player slot and team. The dead ship object is implicitly replaced.
 
-The server does **NOT** auto-respawn for any death type. All ObjCreateTeam messages after
-death are client-initiated.
+**Self-destruct**: The server does NOT auto-respawn. After the 9.5-second explosion animation,
+the client returns to the ship selection screen. The **client** sends ObjCreateTeam (0x03) when
+the player picks a new ship.
 
 ### 4. No DestroyObject Message
 
@@ -124,18 +106,14 @@ See [gamemode-system.md](../planning/gamemode-system.md) for full scoring specif
 ### Server — Combat Kill
 
 1. When hull condition reaches zero from combat damage:
-   a. Create an ObjectExplodingEvent with the killer's player ID and lifetime
+   a. Create an ObjectExplodingEvent with the killer's player ID and lifetime=9.5s
    b. Serialize as PythonEvent (opcode 0x06, factory 0x8129)
    c. Send reliably to all clients
-   d. Send TGSubsystemEvent (factory 0x0101, code 0x800000DF) for each damaged subsystem
-   e. For **weapon kills only**: send Explosion (opcode 0x29) with position, damage, radius
-   f. Process scoring (kill/death/score updates, SCORE_CHANGE broadcast)
-   g. Clear ship state (mark as dead) — do NOT auto-respawn
-   h. Wait for the client to send ObjCreateTeam (0x03) when the player picks a new ship
+   d. Send Explosion (opcode 0x29) with position, damage, and radius
+   e. Process scoring (kill/death/score updates, SCORE_CHANGE broadcast)
+   f. Create a new ship for the same player (ObjCreateTeam, opcode 0x03) — auto-respawn
 
 2. Do NOT send DestroyObject (0x14) for ship deaths — clients do not expect it
-3. Do NOT auto-respawn — the client initiates its own respawn
-4. Do NOT send Explosion (0x29) for collision-induced kills — only for weapon kills
 
 ### Server — Self-Destruct
 
@@ -159,10 +137,9 @@ See [gamemode-system.md](../planning/gamemode-system.md) for full scoring specif
 
 ### Respawn Timing
 
-**All death types**: No server-initiated respawn. After the explosion animation, the
-client returns to the ship selection screen. The client picks a new ship and sends
-ObjCreateTeam (0x03) with the **client's player slot** and team assignment (not the host's
-slot). The server relays this to all other clients.
+**Combat kills**: The server sends the respawn ObjCreateTeam (0x03) immediately after the explosion broadcast. The ship reappears at full health as soon as the server processes the death event.
+
+**Self-destruct**: No server-initiated respawn. The client returns to ship selection after the 9.5-second explosion timer. The respawn ObjCreateTeam uses the **client's player slot** and original team assignment (not the host's slot).
 
 ---
 

--- a/docs/network-flows/join-flow.md
+++ b/docs/network-flows/join-flow.md
@@ -158,42 +158,29 @@ The server responds with:
    connected (dynamic, updates with each join), NOT a fixed player limit. Stock servers
    send 0x01 for 2-player sessions and 0x03 for 3-player sessions.
 
-2. **DeletePlayerUI (0x17)**: Adds the joining player to the engine's internal player list.
-   This message carries a serialized event structure — see
-   [delete-player-ui-wire-format.md](../wire-formats/delete-player-ui-wire-format.md)
-   for the full wire format.
-   ```
-   [0x17][factory_class_id:u32le][event_code:u32le][src_obj_id:u32le][tgt_obj_id:u32le][wire_peer_id:u8]
-   ```
-   Total: 18 bytes (1 opcode + 17 payload).
-
-   At join time, `event_code` carries a "new player" notification (`0x008000F1`).
-   At disconnect time, the same opcode carries a "remove player" notification (`0x00060005`).
-   The `factory_class_id` is always `0x00000866` (base event class).
-
-   **This message is critical for the scoreboard.** The engine's internal player list
-   is populated by this event. Without it, `GetPlayerList()` returns no entries and
-   the scoreboard UI has no players to display, even if score data exists.
-
-3. **Score (0x37)**: Current scores for all players (zeros for new game)
+2. **Score (0x37)**: Current scores for all players (zeros for new game)
    ```
    [0x37][player_id:i32][kills:i32][deaths:i32][score:i32]
    ```
    One `0x37` message is sent per player (not batched). `player_id` is the
    network player ID (`GetNetID()` / wire slot), not an object ID.
 
-4. **ObjCreateTeam (0x03)**: One per already-spawned ship (for late joiners)
+3. **ObjCreateTeam (0x03)**: One per already-spawned ship (for late joiners)
    ```
    [0x03][owner:u8][team:u8][serialized ship data...]
+   ```
+
+4. **DeletePlayerUI (0x17)**: One per connected player slot (UI cleanup)
+   ```
+   [0x17][game_slot:u8]
    ```
 
 ### Late-Join Data
 
 When a player joins an in-progress game, the server sends the full game state:
-- MissionInit (0x35) with current player count
-- DeletePlayerUI (0x17) for the joining player (adds to engine player list)
 - Score message(s) (0x37), one per player, with current kills/deaths/score
 - One ObjCreateTeam (0x03) for every already-spawned ship (cached from original creation)
+- DeletePlayerUI (0x17) for each connected player
 
 This allows the late joiner to see all existing ships and scores immediately.
 

--- a/docs/wire-formats/event-forward-wire-format.md
+++ b/docs/wire-formats/event-forward-wire-format.md
@@ -1,0 +1,191 @@
+# GenericEventForward Wire Format (Opcodes 0x07-0x12, 0x1B)
+
+Wire format specification for Bridge Commander's generic event forwarding mechanism.
+This group of opcodes shares a common handler, payload structure, and relay behavior.
+Documented from network packet captures of stock dedicated servers.
+
+**Clean room statement**: This document contains no decompiled code, no binary addresses,
+no internal memory offsets. All formats and behaviors are derived from observable wire data
+and the shipped Python scripting API.
+
+---
+
+## Overview
+
+Opcodes 0x07 through 0x12 and 0x1B form a **shared event forwarding group**. They all use
+the same receive-side handler, the same relay mechanism, and the same payload structure.
+The only difference between them is the **event code** applied on the receive side — some
+opcodes override the event code from the wire with a fixed value, while others pass through
+the event's own code unchanged.
+
+These opcodes implement the "I did a thing, tell everyone" pattern: a client performs an
+action locally, then broadcasts a notification to all other peers via the server.
+
+**Direction**: Client → Server → All other clients (star topology relay)
+**Reliability**: All sent reliably (ACK required)
+**Relay behavior**: Server forwards the raw message to all connected peers except the
+original sender. No validation, no filtering, no deduplication.
+
+---
+
+## Opcode Table
+
+| Opcode | Name | Event Code Override | Frequency (33.5min, 3 players) |
+|--------|------|---------------------|-------------------------------|
+| 0x07 | StartFiring | 0x008000D7 | 2,918 |
+| 0x08 | StopFiring | 0x008000D9 | 1,448 |
+| 0x09 | StopFiringAtTarget | 0x008000DB | 0 |
+| 0x0A | SubsystemStatusChanged | 0x0080006C | 63 |
+| 0x0B | AddToRepairList | None (pass-through) | 0 |
+| 0x0C | ClientEvent | None (pass-through) | 0 |
+| 0x0E | StartCloaking | 0x008000E3 | 4 |
+| 0x0F | StopCloaking | 0x008000E5 | ~4 |
+| 0x10 | StartWarp | 0x008000ED | 1 |
+| 0x11 | RepairListPriority | None (pass-through) | 0 |
+| 0x12 | SetPhaserLevel | None (pass-through) | 0 |
+| 0x1B | TorpedoTypeChange | 0x008000FD | 12 |
+
+Opcodes with "None (pass-through)" deliver the event with its original event code from the
+wire. Opcodes with an override replace the event code after deserialization.
+
+---
+
+## Message Layout
+
+All opcodes in this group share the same payload structure. The payload is a serialized
+event object using the standard event streaming format:
+
+```
+Offset  Size  Type    Field                    Notes
+------  ----  ----    -----                    -----
+0       1     u8      opcode                   0x07-0x12 or 0x1B
+1       4     i32 LE  event_class_id           Event factory ID (determines payload type)
+5       4     i32 LE  event_code               Event type code (may be overridden by opcode)
+9       4     i32 LE  source_object_id         Object that generated the event
+13      4     i32 LE  related_object_id        Related object (often NULL or -1)
+[17+]   var   ...     class-specific fields    Additional fields based on event_class_id
+```
+
+**Minimum size**: 17 bytes (base event with no class-specific fields).
+
+### Event Class Payloads
+
+| Class ID | Name | Extra Fields | Total Size |
+|----------|------|-------------|------------|
+| 0x0002 | Event (base) | None | 17 bytes |
+| 0x0101 | SubsystemEvent | None (same as base) | 17 bytes |
+| 0x0105 | CharEvent | +1 byte value | 18 bytes |
+| 0x010C | ObjPtrEvent | +4 byte object ID | 21 bytes |
+
+---
+
+## Relay Behavior
+
+### Server Processing
+
+When the server receives a GenericEventForward message:
+
+1. **Relay first**: Forward the raw message bytes to all connected peers except the sender
+   (the "Forward" routing group). This happens before any local processing.
+
+2. **Deserialize**: Construct the appropriate event object from the payload using the
+   event class ID as a factory key.
+
+3. **Event code override** (if applicable): For opcodes with a fixed event code override
+   (see table above), replace the deserialized event's code with the override value.
+
+4. **Local dispatch**: Post the event to the local event system for processing.
+
+### Sender Gating
+
+The handler only forwards events that originate from the **local player's own ship**. Events
+received from remote players are NOT re-forwarded, preventing infinite relay loops. The check
+is: `source_object_id` must belong to the receiving peer's player slot.
+
+### Relay Ratio
+
+In an N-player game, each received event is relayed to (N-1) other peers. Verified from
+a 3-player stock trace:
+
+| Opcode | Received | Wire Total | Ratio |
+|--------|----------|------------|-------|
+| 0x07 StartFiring | 978 | 2,918 | 3:1 (N-1 + 1) |
+| 0x08 StopFiring | 477 | 1,448 | 3:1 |
+| 0x19 TorpedoFire* | 363 | 1,089 | 3:1 |
+| 0x1A BeamFire* | 52 | 156 | 3:1 |
+| 0x1B TorpTypeChange | 4 | 12 | 3:1 |
+
+*TorpedoFire (0x19) and BeamFire (0x1A) are NOT part of this handler group — they have
+their own specialized handlers — but they follow the same relay pattern.
+
+---
+
+## Event Code Override Mechanism
+
+Some opcodes use **sender/receiver event code pairing**. The sender posts one event code
+locally (e.g., "start firing notify"), and the receiver posts a different event code
+(e.g., "start firing"). This is implemented by the opcode-specific override:
+
+| Opcode | Sender Posts Locally | Override (Receiver Posts) |
+|--------|---------------------|--------------------------|
+| 0x07 | Start firing notify | 0x008000D7 (start firing) |
+| 0x08 | Stop firing notify | 0x008000D9 (stop firing) |
+| 0x09 | Stop firing at target notify | 0x008000DB (stop firing at target) |
+| 0x0A | Subsystem status notify | 0x0080006C (subsystem status) |
+| 0x0E | Start cloaking notify | 0x008000E3 (start cloaking) |
+| 0x0F | Stop cloaking notify | 0x008000E5 (stop cloaking) |
+| 0x10 | Start warp notify | 0x008000ED (start warp) |
+| 0x1B | Torpedo type change notify | 0x008000FD (torpedo type changed) |
+
+Opcodes without overrides (0x0B, 0x0C, 0x11, 0x12) use the same event code on both sides.
+
+---
+
+## Server Implementation Notes
+
+### Minimal Implementation
+
+A server only needs to:
+1. Receive the message from the sending client
+2. Relay the raw bytes to all other connected peers
+3. No parsing or validation required for basic relay
+
+### Full Implementation
+
+For a server that tracks game state:
+1. Parse the event payload (class ID, event code, source object)
+2. Verify the source object belongs to the sending player
+3. Apply the event code override if applicable for the opcode
+4. Update local state (e.g., track which ships are cloaked, firing, etc.)
+5. Relay to all other peers
+
+### Rate Limiting
+
+For anti-cheat purposes, the server can rate-limit these messages per source ship:
+- StartFiring/StopFiring: maximum 1 pair per weapon cooldown interval
+- TorpTypeChange: maximum ~1/second
+- StartCloak: maximum ~1/30 seconds (cloak transition time)
+- SetPhaserLevel: maximum ~1/second
+
+---
+
+## Relationship to Other Event Opcodes
+
+| Opcode Group | Handler | Relay? | Notes |
+|--------------|---------|--------|-------|
+| 0x07-0x12, 0x1B | GenericEventForward | Yes (N-1 relay) | This document |
+| 0x06 | PythonEvent | Server-generated | NOT relayed — server creates and sends |
+| 0x0D | PythonEvent2 | C→S only | Client-generated, NOT relayed |
+| 0x19 | TorpedoFire | Yes (N-1 relay) | Separate handler, same relay pattern |
+| 0x1A | BeamFire | Yes (N-1 relay) | Separate handler, same relay pattern |
+| 0x13 | HostMsg | C→S only | Not relayed — server processes locally |
+| 0x15 | CollisionEffect | C→S only | Not relayed — server processes locally |
+
+---
+
+## Related Documents
+
+- **[set-phaser-level-wire-format.md](set-phaser-level-wire-format.md)** — Detailed spec for opcode 0x12 (one member of this group)
+- **[pythonevent-wire-format.md](pythonevent-wire-format.md)** — PythonEvent (0x06) — server-generated events
+- **[protocol-reference.md](../protocol/protocol-reference.md)** — Complete opcode table
+- **[../architecture/server-authority.md](../architecture/server-authority.md)** — Authority model


### PR DESCRIPTION
## Summary
- Add GenericEventForward (0x07-0x12, 0x1B) wire format spec documenting the shared event forwarding group from packet trace analysis
- Document stock dedi bug where SCORE_CHANGE is never sent for weapon kills (only collision/self-destruct kills produce scores)
- Update ship-death-lifecycle with combat auto-respawn behavior observed in traces
- Simplify join-flow DeletePlayerUI documentation

## Files
- **New**: `docs/wire-formats/event-forward-wire-format.md` — full opcode group spec
- **New**: `docs/bugs/bug-reports/20260222-weapon-kill-score-anomaly.md` — stock scoring bug
- **Modified**: `docs/game-systems/ship-death-lifecycle.md` — combat auto-respawn
- **Modified**: `docs/network-flows/join-flow.md` — simplified DeletePlayerUI format

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)