### PR TITLE
fix: MissionInit sends maxPlayers=8 instead of 9

### DIFF
--- a/include/openbc/opcodes.h
+++ b/include/openbc/opcodes.h
@@ -150,7 +150,7 @@
 #define BC_DEFAULT_PORT            0x5655  /* 22101 decimal */
 #define BC_GAMESPY_PORT            0x5656  /* 22102 decimal */
 /* Peer array size: slot 0 = dedicated server, slots 1-8 = up to 8 human players.
- * Stock BC supports 8 human slots; MissionInit totalSlots = BC_MAX_PLAYERS = 9. */
+ * Stock BC supports 8 human slots; MissionInit byte[1] = 8 (human slots only). */
 #define BC_MAX_PLAYERS             9
 
 /* Opcode name lookup (returns static string, NULL for unknown) */

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -100,14 +100,14 @@ void bc_handle_gamespy(bc_socket_t *sock, const bc_addr_t *from,
 /* Stock BC ship-death OBJECT_EXPLODING event visual lifetime. */
 static const f32 BC_SHIP_DEATH_EXPLODING_EVENT_LIFETIME_SEC = 9.5f;
 
-/* MissionInit byte[1] is total slots, including dedicated ghost slot 0.
- * GameSpy maxplayers excludes that slot, so MissionInit = GameSpy + 1. */
+/* MissionInit byte[1] is the human slot count (excluding dedicated ghost
+ * slot 0).  Stock BC sends 8 for an 8-player server. */
 static int bc_mission_init_total_slots(void)
 {
     int human_slots = g_info.maxplayers;
     if (human_slots < 1) human_slots = 1;
     if (human_slots > 8) human_slots = 8;
-    return human_slots + 1;
+    return human_slots;
 }
 
 /* Return a player's name for log output. Falls back to "slot N" if unnamed. */
@@ -1297,7 +1297,7 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
         bc_relay_to_others(peer_slot, payload, payload_len, true);
         /* Respond with MissionInit (0x35) -- tells client which star system
          * to load and what the match rules are.
-         * Byte[1] is total slots (human slots + dedicated ghost slot 0). */
+         * Byte[1] is human slot count (excluding dedicated ghost slot 0). */
         u8 mi[32];
         i32 end_time = (g_round_end_time >= 0.0f) ? (i32)g_round_end_time : 0;
         int total_slots = bc_mission_init_total_slots();

--- a/tests/test_battle.c
+++ b/tests/test_battle.c
@@ -785,9 +785,9 @@ TEST(full_join_flow_multi_client)
             }
 
             CHECK(got_mission);
-            /* MissionInit byte[1] should match server slot limit
-             * (including dedicated ghost slot 0). */
-            CHECK_EQ(mission_total_slots, BC_MAX_PLAYERS);
+            /* MissionInit byte[1] is human slot count
+             * (excluding dedicated ghost slot 0). */
+            CHECK_EQ(mission_total_slots, BC_MAX_PLAYERS - 1);
         }
 
         cl->connected = true;

--- a/tests/test_self_destruct.c
+++ b/tests/test_self_destruct.c
@@ -378,7 +378,7 @@ TEST(mission_init_total_slots_matches_server_limit)
                                                   &msg_len, 2000);
         CHECK(msg != NULL);
         CHECK(msg_len >= 2);
-        CHECK(msg[1] == BC_MAX_PLAYERS); /* human slots + dedicated slot 0 */
+        CHECK(msg[1] == BC_MAX_PLAYERS - 1); /* human slots only */
     }
 
 cleanup:


### PR DESCRIPTION
## Summary

- Remove erroneous `+1` in `bc_mission_init_total_slots()` — stock BC sends 8 (human slots only, excluding dedicated ghost slot 0), not 9
- Update tests to expect `BC_MAX_PLAYERS - 1` (8) instead of `BC_MAX_PLAYERS` (9)
- Fix comments in `opcodes.h` and `server_dispatch.c` to match stock behavior

## Test plan

- [x] `make all` — zero warnings
- [x] `make test` — 18/18 pass (including `mission_init_total_slots_matches_server_limit` and `full_join_flow_multi_client`)

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)