### PR TITLE
docs: per-ship subsystem parity from collision test

### DIFF
--- a/docs/bugs/collision-damage-event-chain.md
+++ b/docs/bugs/collision-damage-event-chain.md
@@ -281,6 +281,90 @@ This prevents clients from generating spurious repair events and ensures only th
 
 ---
 
+## Per-Ship Subsystem Event Verification (2026-02-22)
+
+A 4-minute collision test session with one player cycling through 4 of the 16 flyable ships
+revealed significant variation in subsystem event generation per ship species.
+
+### Test Results
+
+| Species | Ship | Death Type | TGSubsystemEvents | Health Burst | F5 Repair UI |
+|---------|------|------------|-------------------|--------------|--------------|
+| 5 | Sovereign | Collision kill | 1 | No | Not checked |
+| 3 | Galaxy | Collision kill | 9 | No | Not checked |
+| 2 | Ambassador | Self-destruct | 5 | Yes (3 pkts) | Not checked |
+| 8 | Warbird | Self-destruct | 6 | Yes (3 pkts) | **Yes** |
+
+### Key Findings
+
+**1. First-Ship Subsystem Event Deficit**
+
+The Sovereign was the first ship created in the session (obj=0x3FFFFFFF). It generated only
+1 TGSubsystemEvent at collision death, compared to 5-9 for subsequent ships. This suggests
+a registration or initialization timing issue specific to the first ship object created after
+game start. See issue #61 for tracking.
+
+**2. Subsystem IDs Now In Correct Player Range**
+
+All TGSubsystemEvent source IDs were observed in the owning player's object ID range
+(0x3FFFFFFF-0x400FFFFF for player 1). This confirms the subsystem ID allocation fix (#58)
+is working — clients can now resolve damage events via ReadObjectRef.
+
+**3. Health Burst Asymmetry (Self-Destruct vs. Collision Kill)**
+
+Self-destruct deaths produce a "health burst" — 3 StateUpdate packets (flag 0x20) with all
+subsystem health values zeroed. This burst appears immediately before the ObjectExplodingEvent.
+
+Collision kills do **not** produce a health burst. The ship dies without a final subsystem
+state broadcast. This is a behavioral divergence from self-destruct that may affect client-side
+repair UI updates.
+
+**4. End-to-End Chain Verified (Warbird)**
+
+The Warbird (species 8, 4th ship) provided the first end-to-end verification of the full
+chain: collision damage → subsystem condition update → repair queue addition → PythonEvent
+broadcast → client F5 engineering screen showing damaged subsystems. This confirms the
+entire pipeline from collision detection through client UI is functional.
+
+### Per-Ship Detail
+
+**Sovereign (species 5, obj=0x3FFFFFFF, 1st ship):**
+- StateUpdate 0x20: Yes, round-robin indices 0,5,7,9
+- TGSubsystemEvents at death: 1 (subsys=0x40000000, repair=0x4000000E)
+- Health burst: No (collision kill)
+- **Status: BROKEN** — first-ship deficit, 1 vs expected ~13
+
+**Galaxy (species 3, obj=0x40000021, 2nd ship):**
+- StateUpdate 0x20: Yes, round-robin indices 0,5,7,9,4,6+; values 0x0F, 0x40, 0xCC, 0x60
+- TGSubsystemEvents at non-lethal collision: 2 (IDs 0x4000002E, 0x40000042)
+- TGSubsystemEvents at death: 9 (IDs 0x2F-0x35, 0x40-0x41)
+- Health burst: No (collision kill)
+- **Status: BEST RESULT** — 9/~13 parity
+
+**Ambassador (species 2, obj=0x40000044, 3rd ship):**
+- StateUpdate 0x20: Yes; values 0xE5, 0x20, 0x66
+- TGSubsystemEvents at self-destruct: 5 (IDs 0x45, 0x46, 0x48, 0x4D, 0x5D)
+- Health burst: Yes (3 StateUpdate packets, all subsystems zeroed)
+- **Status: PARTIAL** — 5/~13 parity
+
+**Warbird (species 8, obj=0x40000062, 4th ship):**
+- StateUpdate 0x20: Yes; values 0xBF, 0x40, 0x60, 0x6D, 0x1F
+- TGSubsystemEvents at self-destruct: 6 (IDs 0x64, 0x65, 0x67, 0x69, 0x6E, 0x78)
+- Health burst: Yes (3 StateUpdate packets, all subsystems zeroed)
+- F5 Repair UI: **Confirmed working** — engineering screen showed damaged subsystems
+- **Status: WORKING** — 6/~13 parity, full end-to-end chain verified
+
+### Remaining Ships (12 Untested)
+
+The following species have not yet been tested for subsystem event parity:
+Akira (1), Nebula (4), Bird of Prey (6), Vorcha (7), Marauder (9), Galor (10),
+Keldon (11), CardHybrid (12), KessokHeavy (13), KessokLight (14), Shuttle (15),
+CardFreighter (16).
+
+Per-ship tracking comments are maintained on issue #63.
+
+---
+
 ## Related Documents
 
 - **[collision-effect-wire-format.md](../wire-formats/collision-effect-wire-format.md)** — Opcode 0x15 wire format and host validation checks

--- a/docs/game-systems/ship-death-lifecycle.md
+++ b/docs/game-systems/ship-death-lifecycle.md
@@ -90,6 +90,37 @@ DestroyObject may be used for:
 - Player disconnect cleanup
 - Single-player scenarios
 
+### 5. Subsystem Health Burst on Death
+
+The death sequence includes a **subsystem health burst** for self-destruct kills but
+**not** for collision kills:
+
+#### Self-Destruct Death
+
+Immediately before the ObjectExplodingEvent, the server sends **3 StateUpdate packets**
+(flag 0x20) containing zeroed health values for all subsystems. This burst provides clients
+with a definitive final state — all subsystems are at 0% health.
+
+Observed in Ambassador (species 2) and Warbird (species 8) self-destruct deaths:
+- 3 StateUpdate packets with flag 0x20
+- All subsystem health values zeroed
+- Burst arrives before the ObjectExplodingEvent (factory 0x8129)
+
+#### Collision Kill Death
+
+Collision kills do **not** produce a health burst. The ship dies without a final subsystem
+state broadcast — the last subsystem health values the client received were from the most
+recent round-robin StateUpdate cycle before death.
+
+This means clients may display stale subsystem health for collision-killed ships during the
+9.5-second explosion animation. This is a behavioral divergence from self-destruct, but it
+matches stock server behavior.
+
+#### Implementation Note
+
+Servers should send the 3-packet health burst for self-destruct deaths but may omit it for
+combat kills (collision, weapon, explosion) to match stock behavior.
+
 ---
 
 ## Scoring Interaction

--- a/docs/network-flows/wire-format-audit.md
+++ b/docs/network-flows/wire-format-audit.md
@@ -462,8 +462,10 @@ S->C: MissionInit(0x35)                               <-- WRONG: should wait for
 
 ## Collision Test (2026-02-22)
 
-**Source**: Side-by-side packet traces — stock dedi vs OpenBC, same scenario (Sovereign,
-environment collision, death, respawn, second collision).
+**Source**: Side-by-side packet traces — stock dedi vs OpenBC. Initial test: Sovereign,
+environment collision, death, respawn, second collision. Follow-up (same date): 4m 24s
+session with 1 player cycling through 4 of 16 flyable ships (Sovereign, Galaxy, Ambassador,
+Warbird) across 3 species (Federation, Federation, Romulan).
 
 ### Per-Opcode Match Status
 
@@ -480,24 +482,42 @@ environment collision, death, respawn, second collision).
 | 0x1C | StateUpdate | **MATCH** | Structure correct (flags, CF16, CompressedVector) |
 | 0x06 (0x8129) | ObjectExplodingEvent | **MATCH** | Factory, event, fields identical (lifetime differs) |
 | 0x06 (0x0101) | TGSubsystemEvent | **MATCH** (structure) | Wire format correct BUT object IDs from wrong range |
+| 0x13 | HostMsg (self-destruct) | **MATCH** | 1-byte opcode, no payload, triggers death chain |
 | 0x36 | ScoreChange | **MATCH** | `36 00 00 00 00 02 00 00 00 01 00 00 00 00` identical |
+| 0x03 | ObjCreateTeam (multi-species) | **MATCH** | 4 species tested (2,3,5,8) — all create correctly |
 | 0x35 | MissionInit | **MISMATCH** | byte[0]: stock=0x08, OpenBC=0x07 (off-by-one) |
 | 0x17 | DeletePlayerUI | **MISSING** | Stock sends at join, OpenBC doesn't |
-| 0x29 | Explosion | **SPURIOUS** | OpenBC sends for collision kill, stock doesn't |
+| 0x29 | Explosion | ~~SPURIOUS~~ **FIXED** | #60: no longer sent for collision kills |
 
 ### Behavioral Gaps (separate issues filed)
 
-| # | Gap | Severity | Issue |
-|---|-----|----------|-------|
-| 1 | Post-respawn collision ownership stale | HIGH | Filed |
-| 2 | Subsystem object IDs from wrong range | HIGH | Filed |
-| 3 | Missing DeletePlayerUI (0x17) at join | MEDIUM | Filed |
-| 4 | Spurious Explosion (0x29) on collision kill | MEDIUM | Filed |
-| 5 | Too few SubsystemDamage events at death | MEDIUM | Filed |
-| 6 | MissionInit maxPlayers 7 vs 8 | LOW | Filed |
+| # | Gap | Severity | Issue | Status |
+|---|-----|----------|-------|--------|
+| 1 | Post-respawn collision ownership stale | HIGH | #57 | Open |
+| 2 | ~~Subsystem object IDs from wrong range~~ | ~~HIGH~~ | #58 | **FIXED** |
+| 3 | Missing DeletePlayerUI (0x17) at join | MEDIUM | #59 | Open |
+| 4 | ~~Spurious Explosion (0x29) on collision kill~~ | ~~MEDIUM~~ | #60 | **FIXED** |
+| 5 | Too few SubsystemDamage events at death | MEDIUM | #61 | Open (per-ship data on #63) |
+| 6 | MissionInit maxPlayers 7 vs 8 | LOW | #62 | Open |
+| 7 | ~~Combat death auto-respawn~~ | ~~HIGH~~ | #38 | **FIXED** |
 
 See [20260222-collision-test-parity-gaps.md](../bugs/bug-reports/20260222-collision-test-parity-gaps.md)
 for full details with hex dumps and server log excerpts.
+
+### Per-Ship Subsystem Event Breakdown (4 of 16 ships tested)
+
+| Species | Ship | Death | TGSubsystemEvents | Health Burst | Repair UI |
+|---------|------|-------|-------------------|--------------|-----------|
+| 5 | Sovereign | Collision | 1 / ~13 | No | — |
+| 3 | Galaxy | Collision | 9 / ~13 | No | — |
+| 2 | Ambassador | Self-destruct | 5 / ~13 | Yes (3 pkts) | — |
+| 8 | Warbird | Self-destruct | 6 / ~13 | Yes (3 pkts) | **Yes** |
+
+- **First-ship deficit**: Sovereign (1st object created) has 1 event vs 5-9 for later ships
+- **Health burst**: Self-destruct deaths send 3 StateUpdate flag=0x20 packets; collision kills do not
+- **End-to-end verified**: Warbird F5 repair UI showed damaged subsystems on client
+
+Per-ship tracking comments maintained on #63.
 
 ### Not Yet Tested
 


### PR DESCRIPTION
## Summary
- Add per-ship subsystem event verification section to `collision-damage-event-chain.md` with data from 4 tested ships (Sovereign, Galaxy, Ambassador, Warbird)
- Add subsystem health burst on death subsection to `ship-death-lifecycle.md` documenting self-destruct vs collision kill asymmetry
- Update `wire-format-audit.md` with per-ship breakdown table, HostMsg (0x13) MATCH, multi-species ObjCreateTeam verified, and mark #58/#60/#38 as FIXED

## Test plan
- [x] All content is clean-room safe (no binary addresses, no function names)
- [x] Per-ship data matches packet trace observations
- [x] Cross-references to issues #58, #60, #38, #61, #63 are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)