### PR TITLE
fix: correct collision damage pipeline (issue #87)

### DIFF
--- a/include/openbc/combat.h
+++ b/include/openbc/combat.h
@@ -65,26 +65,32 @@ int bc_combat_shield_facing(const bc_ship_state_t *target,
                             bc_vec3_t impact_dir);
 
 /* Find all subsystems whose AABB overlaps the damage volume.
- * Each subsystem AABB = [pos - radius, pos + radius] per axis.
+ * Each subsystem AABB expanded by search_radius: [pos - r*sr, pos + r*sr].
  * Damage AABB = [impact - damage_radius, impact + damage_radius].
+ * search_radius scales each subsystem's effective bounding radius (1.0 = normal,
+ * 1.5 = find subsystems within 1.5x their radius from the damage origin).
  * Returns count of overlapping subsystems written to out_indices. */
 int bc_combat_find_hit_subsystems(const bc_ship_class_t *cls,
                                   bc_vec3_t local_impact, f32 damage_radius,
+                                  f32 search_radius,
                                   int *out_indices, int max_out);
 
 /* Apply damage to target with shield absorption.
  * impact_dir = normalized direction from attacker to target.
  * area_effect: true = damage/6 per shield facing, false = single facing.
  * damage_radius: used for subsystem AABB overlap test (scaled by target's
- * damage_radius_multiplier; if multiplier is 0.0, subsystem damage skipped).
- * shield_scale: multiplier on shield absorption capacity (1.0 = normal,
- * 1.5 = collision shields absorb 50% more before overflow). */
+ * damage_radius_multiplier; pass 0.0 to skip subsystem damage).
+ * search_radius: spatial search expansion factor for subsystem hit detection.
+ *   Each subsystem's bounding radius is scaled by this value in the AABB test.
+ *   1.0 = normal (weapons); 1.5 = collision path (wider spatial search).
+ * Pipeline: shields absorb first; hit subsystems absorb from overflow
+ * independently (each up to min(overflow, ss_hp)); hull gets remainder. */
 void bc_combat_apply_damage(bc_ship_state_t *target,
                             const bc_ship_class_t *cls,
                             f32 damage, f32 damage_radius,
                             bc_vec3_t impact_dir,
                             bool area_effect,
-                            f32 shield_scale);
+                            f32 search_radius);
 
 /* Path 1 — Direct collision: raw * 0.1 + 0.1, cap 0.5 (fractional). */
 f32 bc_combat_collision_damage_path1(f32 collision_energy, f32 ship_mass,

--- a/src/game/combat.c
+++ b/src/game/combat.c
@@ -258,9 +258,12 @@ int bc_combat_shield_facing(const bc_ship_state_t *target,
 }
 
 /* Bug 1: AABB overlap test — find ALL subsystems whose bounding box overlaps
- * the damage volume, not just the nearest point-sphere hit. */
+ * the damage volume, not just the nearest point-sphere hit.
+ * search_radius scales each subsystem's effective bounding radius in the test,
+ * expanding the set of eligible subsystems (1.5 = 50% wider search per subsystem). */
 int bc_combat_find_hit_subsystems(const bc_ship_class_t *cls,
                                   bc_vec3_t local_impact, f32 damage_radius,
+                                  f32 search_radius,
                                   int *out_indices, int max_out)
 {
     int count = 0;
@@ -269,15 +272,16 @@ int bc_combat_find_hit_subsystems(const bc_ship_class_t *cls,
         const bc_subsystem_def_t *ss = &cls->subsystems[i];
         if (ss->radius <= 0.0f) continue;
 
-        /* Subsystem AABB: [pos - radius, pos + radius] per axis */
-        /* Damage AABB:    [impact - damage_radius, impact + damage_radius] */
-        /* Overlap requires all 3 axes to overlap */
-        bool overlap_x = (local_impact.x - damage_radius) <= (ss->position.x + ss->radius) &&
-                          (local_impact.x + damage_radius) >= (ss->position.x - ss->radius);
-        bool overlap_y = (local_impact.y - damage_radius) <= (ss->position.y + ss->radius) &&
-                          (local_impact.y + damage_radius) >= (ss->position.y - ss->radius);
-        bool overlap_z = (local_impact.z - damage_radius) <= (ss->position.z + ss->radius) &&
-                          (local_impact.z + damage_radius) >= (ss->position.z - ss->radius);
+        /* Subsystem AABB expanded by search_radius: [pos - r*sr, pos + r*sr] */
+        /* Damage AABB: [impact - damage_radius, impact + damage_radius]       */
+        /* Overlap requires all 3 axes to overlap                               */
+        f32 ss_r = ss->radius * search_radius;
+        bool overlap_x = (local_impact.x - damage_radius) <= (ss->position.x + ss_r) &&
+                          (local_impact.x + damage_radius) >= (ss->position.x - ss_r);
+        bool overlap_y = (local_impact.y - damage_radius) <= (ss->position.y + ss_r) &&
+                          (local_impact.y + damage_radius) >= (ss->position.y - ss_r);
+        bool overlap_z = (local_impact.z - damage_radius) <= (ss->position.z + ss_r) &&
+                          (local_impact.z + damage_radius) >= (ss->position.z - ss_r);
 
         if (overlap_x && overlap_y && overlap_z) {
             out_indices[count++] = i;
@@ -288,13 +292,17 @@ int bc_combat_find_hit_subsystems(const bc_ship_class_t *cls,
 
 /* Bug 7: area-effect vs directed shield absorption.
  * Bug 9: skip shield absorption when cloaked.
- * Bug 10: damage_radius scaled by target's damage_radius_multiplier. */
+ * Bug 10: damage_radius scaled by target's damage_radius_multiplier.
+ * Issue #87: two-step pipeline — subsystems absorb before hull; each hit
+ * subsystem independently absorbs up to min(overflow, ss_hp); hull gets
+ * max(0, overflow - total_sub_absorbed). search_radius expands each
+ * subsystem's effective AABB radius for the hit test (1.5 = collision path). */
 void bc_combat_apply_damage(bc_ship_state_t *target,
                             const bc_ship_class_t *cls,
                             f32 damage, f32 damage_radius,
                             bc_vec3_t impact_dir,
                             bool area_effect,
-                            f32 shield_scale)
+                            f32 search_radius)
 {
     if (!target->alive || damage <= 0.0f) return;
 
@@ -309,10 +317,9 @@ void bc_combat_apply_damage(bc_ship_state_t *target,
         f32 total_absorbed = 0.0f;
         for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) {
             f32 absorbed = per_facing;
-            f32 facing_capacity = target->shield_hp[i] * shield_scale;
-            if (absorbed > facing_capacity)
-                absorbed = facing_capacity;
-            target->shield_hp[i] -= absorbed / shield_scale;
+            if (absorbed > target->shield_hp[i])
+                absorbed = target->shield_hp[i];
+            target->shield_hp[i] -= absorbed;
             total_absorbed += absorbed;
         }
         overflow = damage - total_absorbed;
@@ -320,12 +327,11 @@ void bc_combat_apply_damage(bc_ship_state_t *target,
         /* Directed: single facing absorbs */
         int facing = bc_combat_shield_facing(target, impact_dir);
         if (target->shield_hp[facing] > 0.0f) {
-            f32 shield_capacity = target->shield_hp[facing] * shield_scale;
-            if (damage <= shield_capacity) {
-                target->shield_hp[facing] -= damage / shield_scale;
+            if (damage <= target->shield_hp[facing]) {
+                target->shield_hp[facing] -= damage;
                 return; /* fully absorbed */
             }
-            overflow = damage - shield_capacity;
+            overflow = damage - target->shield_hp[facing];
             target->shield_hp[facing] = 0.0f;
         } else {
             overflow = damage;
@@ -334,15 +340,10 @@ void bc_combat_apply_damage(bc_ship_state_t *target,
 
     if (overflow <= 0.0f) return;
 
-    /* Hull damage */
-    target->hull_hp -= overflow;
-    if (target->hull_hp <= 0.0f) {
-        target->hull_hp = 0.0f;
-        target->alive = false;
-    }
-
-    /* Subsystem damage: AABB overlap test */
-    /* Bug 10: scale damage_radius by target's multiplier */
+    /* Step 1: Subsystem absorption — subsystems absorb from overflow BEFORE hull.
+     * Each hit subsystem independently absorbs up to min(overflow, ss_hp).
+     * Bug 10: scale damage_radius by target's multiplier. */
+    f32 total_sub_absorbed = 0.0f;
     f32 effective_radius = damage_radius * cls->damage_radius_multiplier;
     if (effective_radius > 0.0f) {
         bc_vec3_t right = bc_vec3_cross(target->fwd, target->up);
@@ -352,31 +353,37 @@ void bc_combat_apply_damage(bc_ship_state_t *target,
             bc_vec3_dot(impact_dir, target->up),
         };
 
-        /* Bug 1: find ALL overlapping subsystems */
+        /* Bug 1: find ALL overlapping subsystems (search_radius scales ss AABB) */
         int hit_indices[BC_MAX_SUBSYSTEMS];
         int hit_count = bc_combat_find_hit_subsystems(cls, local,
                                                        effective_radius,
+                                                       search_radius,
                                                        hit_indices,
                                                        BC_MAX_SUBSYSTEMS);
 
         for (int h = 0; h < hit_count; h++) {
             int ss_idx = hit_indices[h];
             if (target->subsystem_hp[ss_idx] > 0.0f) {
-                f32 sub_dmg = overflow * 0.5f;
-                target->subsystem_hp[ss_idx] -= sub_dmg;
-                if (target->subsystem_hp[ss_idx] < 0.0f) {
+                /* Each subsystem absorbs up to the full overflow independently. */
+                f32 absorbed = overflow;
+                if (absorbed > target->subsystem_hp[ss_idx])
+                    absorbed = target->subsystem_hp[ss_idx];
+                target->subsystem_hp[ss_idx] -= absorbed;
+                if (target->subsystem_hp[ss_idx] < 0.0f)
                     target->subsystem_hp[ss_idx] = 0.0f;
-                }
-                /* Propagate 25% to parent container */
-                int parent = cls->subsystems[ss_idx].parent_idx;
-                if (parent >= 0 && target->subsystem_hp[parent] > 0.0f) {
-                    target->subsystem_hp[parent] -= sub_dmg * 0.25f;
-                    if (target->subsystem_hp[parent] < 0.0f) {
-                        target->subsystem_hp[parent] = 0.0f;
-                    }
-                }
+                total_sub_absorbed += absorbed;
             }
         }
+    }
+
+    /* Step 2: Hull gets overflow minus what subsystems absorbed. */
+    f32 hull_damage = overflow - total_sub_absorbed;
+    if (hull_damage <= 0.0f) return;
+
+    target->hull_hp -= hull_damage;
+    if (target->hull_hp <= 0.0f) {
+        target->hull_hp = 0.0f;
+        target->alive = false;
     }
 }
 

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -1615,7 +1615,7 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
 
                     bc_combat_apply_damage(&target->ship, tcls, dmg,
                                            collision_radius, scaled_impact,
-                                           false, 1.0f);
+                                           false, 1.5f);
 
                     f32 target_shield_after = total_shields(&target->ship);
                     f32 target_hull_after = target->ship.hull_hp;
@@ -1753,7 +1753,7 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
 
                         bc_combat_apply_damage(&source->ship, scls, sdmg,
                                                src_coll_radius, src_scaled,
-                                               false, 1.0f);
+                                               false, 1.5f);
 
                         f32 source_shield_after = total_shields(&source->ship);
                         f32 source_hull_after = source->ship.hull_hp;

--- a/tests/test_combat_damage.c
+++ b/tests/test_combat_damage.c
@@ -1,0 +1,217 @@
+/*
+ * test_combat_damage.c — Regression tests for issue #87
+ *
+ * Verifies the three structural fixes to bc_combat_apply_damage:
+ *
+ *   A. Subsystems absorb BEFORE hull (ordering fix).
+ *      Old: hull took full overflow; subsystems took overflow*0.5 additionally.
+ *      New: subsystems absorb from overflow first; hull gets the remainder.
+ *
+ *   B. Full per-contact damage to each hit subsystem (no 0.5x multiplier),
+ *      and no 25% propagation to parent containers.
+ *
+ *   C. search_radius parameter expands each subsystem's effective AABB radius
+ *      for the hit test (was incorrectly used as shield HP multiplier).
+ *
+ * Test ship: Galaxy-class (species_id=3, loaded from registry).
+ * Subsystems referenced:
+ *   Forward Torpedo 1..4  torpedo_tube  pos=[0,-0.25,-0.25]  r=0.20  HP=2400
+ *   Sensor Array          sensor        pos=[0,-0.45,-0.50]  r=0.28  HP=8000
+ *   Shield Generator      shield        pos=[0,-0.40, 0.20]  r=0.50  HP=12000
+ *   Hull                  hull          pos=[0,-1.50,-0.50]  r=1.00  HP=15000
+ *
+ * All tests use a default-oriented ship (fwd={0,1,0}, up={0,0,1}),
+ * so local_impact == impact_dir inside bc_combat_apply_damage.
+ */
+
+#include "test_util.h"
+#include "openbc/ship_data.h"
+#include "openbc/ship_state.h"
+#include "openbc/combat.h"
+#include "openbc/game_builders.h"
+#include <string.h>
+#include <math.h>
+#include <stdio.h>
+
+#define REGISTRY_DIR "data/vanilla-1.1"
+
+static bc_game_registry_t g_reg;
+
+TEST(load_registry)
+{
+    ASSERT(bc_registry_load_dir(&g_reg, REGISTRY_DIR));
+}
+
+/*
+ * Issue #87-A and #87-B: Ordering fix + full per-contact absorption.
+ *
+ * Galaxy, shields stripped, impact at Forward Torpedo position [0,-0.25,-0.25]
+ * with damage_radius=0.1. Several subsystems are within this radius (4 torpedo
+ * tubes at HP=2400 each, Sensor Array at HP=8000, Shield Generator at HP=12000).
+ * damage = 3000 HP.
+ *
+ * OLD (bug): each tube took overflow*0.5 = 1500 HP (survived at 900 HP),
+ *            hull took full 3000 HP damage regardless.
+ *
+ * NEW (fix): each tube absorbs min(3000, 2400) = 2400 HP independently;
+ *            combined absorption easily exceeds 3000, so hull takes 0 damage.
+ */
+TEST(subsystem_absorbs_full_before_hull)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3); /* Galaxy */
+    ASSERT(cls != NULL);
+
+    /* Locate first torpedo tube (all forward tubes share [0,-0.25,-0.25]) */
+    int torp_ss = -1;
+    for (int i = 0; i < cls->subsystem_count; i++) {
+        if (strcmp(cls->subsystems[i].type, "torpedo_tube") == 0 &&
+            cls->subsystems[i].radius > 0.0f) {
+            torp_ss = i;
+            break;
+        }
+    }
+    ASSERT(torp_ss >= 0);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) ship.shield_hp[i] = 0.0f;
+
+    f32 hull_before = ship.hull_hp;
+    bc_vec3_t impact = cls->subsystems[torp_ss].position; /* [0, -0.25, -0.25] */
+    f32 damage = 3000.0f;
+
+    bc_combat_apply_damage(&ship, cls, damage, 0.1f, impact, false, 1.0f);
+
+    /* Torpedo tube must have absorbed its full HP (2400), not 0.5*3000=1500.
+     * HP=2400-2400=0, not HP=2400-1500=900. */
+    ASSERT(ship.subsystem_hp[torp_ss] < 0.01f);
+
+    /* Hull must have received 0 damage — subsystems collectively absorbed all
+     * of overflow (total absorption >> 3000), so hull_damage=max(0,3000-N)=0.
+     * Old code gave hull the full 3000 regardless of subsystem absorption. */
+    f32 hull_delta = hull_before - ship.hull_hp;
+    ASSERT(hull_delta < 0.01f);
+}
+
+/*
+ * Issue #87-B: No 25% propagation to parent container.
+ *
+ * Torpedo tubes have a parent container ("Torpedoes" system HP slot).
+ * The old code propagated 25% of sub_dmg to the parent's HP slot.
+ * The new code only modifies the directly hit subsystem's HP.
+ */
+TEST(no_parent_propagation)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    /* Find first torpedo tube that has a parent container */
+    int child_ss = -1;
+    int parent_slot = -1;
+    for (int i = 0; i < cls->subsystem_count; i++) {
+        int p = cls->subsystems[i].parent_idx;
+        if (strcmp(cls->subsystems[i].type, "torpedo_tube") == 0 &&
+            cls->subsystems[i].radius > 0.0f && p >= 0) {
+            child_ss = i;
+            parent_slot = p;
+            break;
+        }
+    }
+    if (child_ss < 0) return; /* Skip — ship has no parent-child torpedo pair */
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) ship.shield_hp[i] = 0.0f;
+
+    f32 parent_hp_before = ship.subsystem_hp[parent_slot]; /* "Torpedoes" HP */
+
+    /* damage_radius=0.1 at the torpedo position triggers subsystem search and
+     * hits the torpedo tube (and nearby subsystems — see file header).
+     * The torpedo parent slot is a container with no spatial position/radius,
+     * so it is not in the hit list itself. */
+    bc_vec3_t impact = cls->subsystems[child_ss].position;
+    bc_combat_apply_damage(&ship, cls, 3000.0f, 0.1f, impact, false, 1.0f);
+
+    /* Parent HP slot must be unchanged — no 25% propagation.
+     * Old code: parent_hp -= overflow*0.5*0.25 = 375 (observable change).
+     * New code: parent_hp untouched. */
+    ASSERT(fabsf(ship.subsystem_hp[parent_slot] - parent_hp_before) < 0.01f);
+}
+
+/*
+ * Issue #87-C: search_radius expands each subsystem's effective AABB radius.
+ *
+ * Impact placed at (ss_pos.y + ss_r * 1.2) on the Y axis — just outside the
+ * 1.0x radius boundary but inside the 1.5x boundary.
+ *
+ * search_radius=1.0: effective ss radius = ss_r → impact outside → torpedo tube NOT hit → HP unchanged.
+ * search_radius=1.5: effective ss radius = 1.5*ss_r → impact inside → torpedo tube HIT → HP decreases.
+ *
+ * The torpedo tube HP is checked directly (not hull_delta) to avoid interference
+ * from other large-radius subsystems (e.g. Shield Generator r=0.50) that may
+ * overlap the impact point independently of search_radius.
+ *
+ * A tiny positive damage_radius (0.001) is used to trigger the subsystem search
+ * path (effective_radius > 0) without meaningfully expanding the hit zone.
+ */
+TEST(search_radius_expands_hit_set)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    /* Use first torpedo tube: pos=[0,-0.25,-0.25], radius=0.2 */
+    int torp_ss = -1;
+    for (int i = 0; i < cls->subsystem_count; i++) {
+        if (strcmp(cls->subsystems[i].type, "torpedo_tube") == 0 &&
+            cls->subsystems[i].radius > 0.0f) {
+            torp_ss = i;
+            break;
+        }
+    }
+    ASSERT(torp_ss >= 0);
+
+    f32 ss_r = cls->subsystems[torp_ss].radius;  /* 0.2 */
+    bc_vec3_t ss_pos = cls->subsystems[torp_ss].position; /* [0,-0.25,-0.25] */
+
+    /* Impact at 1.2*ss_r beyond the subsystem center on Y (= -0.25 + 0.24 = -0.01).
+     * With sr=1.0: ss_r_test=0.2, impact_y=-0.01 > ss_pos.y+0.2=-0.05 → NOT hit.
+     * With sr=1.5: ss_r_test=0.3, impact_y=-0.01 <= ss_pos.y+0.3=0.05  → HIT. */
+    bc_vec3_t impact = { ss_pos.x, ss_pos.y + ss_r * 1.2f, ss_pos.z };
+    f32 damage = 1000.0f;
+    f32 damage_radius = 0.001f; /* tiny positive value to enter subsystem search */
+
+    /* --- search_radius=1.0: impact outside torpedo tube effective radius → tube not hit --- */
+    {
+        bc_ship_state_t ship;
+        bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+        for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) ship.shield_hp[i] = 0.0f;
+        f32 torp_hp_before = ship.subsystem_hp[torp_ss];
+
+        bc_combat_apply_damage(&ship, cls, damage, damage_radius, impact, false, 1.0f);
+
+        /* Torpedo tube is outside 1.0x effective radius → HP must be unchanged.
+         * Other subsystems (e.g. Shield Generator) may still absorb, but that does
+         * not affect this assertion which targets only the torpedo tube slot. */
+        ASSERT(fabsf(ship.subsystem_hp[torp_ss] - torp_hp_before) < 0.01f);
+    }
+
+    /* --- search_radius=1.5: impact inside expanded radius → torpedo tube is hit --- */
+    {
+        bc_ship_state_t ship;
+        bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+        for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) ship.shield_hp[i] = 0.0f;
+        f32 torp_hp_before = ship.subsystem_hp[torp_ss];
+
+        bc_combat_apply_damage(&ship, cls, damage, damage_radius, impact, false, 1.5f);
+
+        /* Torpedo tube is inside 1.5x effective radius → HP must have decreased. */
+        ASSERT(ship.subsystem_hp[torp_ss] < torp_hp_before - 0.01f);
+    }
+}
+
+TEST_MAIN_BEGIN()
+    RUN(load_registry);
+    RUN(subsystem_absorbs_full_before_hull);
+    RUN(no_parent_propagation);
+    RUN(search_radius_expands_hit_set);
+TEST_MAIN_END()

--- a/tests/test_networked_battle.c
+++ b/tests/test_networked_battle.c
@@ -295,7 +295,7 @@ static void nb_apply_damage(battle_player_t *target, battle_player_t *attacker,
     };
     int hit_indices[BC_MAX_SUBSYSTEMS];
     int hit_count = bc_combat_find_hit_subsystems(target->cls, local, 1.0f,
-                                                   hit_indices, BC_MAX_SUBSYSTEMS);
+                                                   1.0f, hit_indices, BC_MAX_SUBSYSTEMS);
     int ss_idx = (hit_count > 0) ? hit_indices[0] : -1;
 
     if (ss_idx >= 0 && ss_idx < target->subsys_count &&


### PR DESCRIPTION
## Summary

- **Fix A — Ordering**: Subsystems now absorb from overflow *before* hull receives the remainder. Old code applied hull damage from full overflow regardless of subsystem absorption; new code: `hull_damage = max(0, overflow - total_sub_absorbed)`.
- **Fix B — Multipliers**: Removed the `overflow * 0.5f` per-subsystem damage multiplier and 25% parent-container propagation. Each hit subsystem independently absorbs `min(overflow, ss_hp)` with no spill to parent slots.
- **Fix C — `search_radius` semantics**: Renamed `shield_scale` → `search_radius`; removed incorrect shield HP scaling. `search_radius` now correctly scales each subsystem's AABB bounding radius in `bc_combat_find_hit_subsystems`. Collision call sites in `server_dispatch.c` pass `1.5`; weapon call sites remain `1.0`.

## Changes

| File | Change |
|------|--------|
| `src/game/combat.c` | Restructure `bc_combat_apply_damage` (two-step pipeline); add `search_radius` param to `bc_combat_find_hit_subsystems` |
| `include/openbc/combat.h` | Update signatures and doc comments for both functions |
| `src/server/server_dispatch.c` | Collision call sites: `1.0f` → `1.5f` for `search_radius` |
| `tests/test_networked_battle.c` | Update `bc_combat_find_hit_subsystems` call to new signature |
| `tests/test_combat_damage.c` | New: 4 regression tests covering fixes A, B, C |

## Testing

- [x] `make all` — zero warnings (`-Wall -Wextra -Wpedantic`)
- [x] `make test` — 19/19 suites pass
- [x] `test_combat_damage` — 4 new regression tests all pass:
  - `load_registry` — Galaxy class loads from `data/vanilla-1.1`
  - `subsystem_absorbs_full_before_hull` — torpedo tube absorbs full 2400 HP, hull takes 0
  - `no_parent_propagation` — parent HP slot unchanged after child torpedo tube is hit
  - `search_radius_expands_hit_set` — torpedo tube HP unchanged at `sr=1.0`, decreased at `sr=1.5`

Closes #87