### PR TITLE
Update README, CLAUDE.md, AGENTS.md for current project state

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,7 +145,7 @@ All platforms use `-std=c11 -Wall -Wextra -Wpedantic`. Zero warnings policy.
 ## Project Structure
 
 - `src/` -- C source (checksum, game, json, network, protocol, server)
-- `tests/` -- 11 test suites (unit via `test_util.h`, integration via `test_harness.h`)
+- `tests/` -- 19 test suites (unit via `test_util.h`, integration via `test_harness.h`)
 - `docs/` -- Clean room protocol documentation (the single source of truth)
 - `data/` -- Ship/projectile registry (JSON, machine-generated)
 - `manifests/` -- Hash manifests for file integrity verification

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,15 +72,15 @@ All design documents live in `docs/` organized by topic. See [docs/README.md](do
 ```
 src/
 ├── checksum/      # Hash algorithms, manifest validation
-├── game/          # Ship data registry, ship state, movement, combat simulation
+├── game/          # Ship data registry, ship state, power, movement, combat, torpedo tracking
 ├── json/          # Lightweight JSON parser
 ├── network/       # UDP transport, peer management, reliability, GameSpy
 ├── protocol/      # Wire codec, opcodes, handshake, game events
-└── server/        # Main entry point, config, logging
+└── server/        # Main entry point, config, logging, dispatch, state, stats
 tools/             # CLI tools (hash manifest, data scraper, diagnostics)
 data/              # Ship and projectile data (vanilla-1.1/)
 manifests/         # Precomputed hash manifests (vanilla-1.1.json)
-tests/             # 11 test suites (unit + integration)
+tests/             # 19 test suites (unit + integration)
 docs/              # Design documents and protocol reference
 ```
 
@@ -120,12 +120,13 @@ Hard-won bugs — do not repeat:
 ## Key Source Files
 
 - Server entry: `src/server/main.c`
+- Server subsystems: `src/server/{server_state,server_send,server_handshake,server_dispatch,server_stats}.c`
 - Protocol codec/cipher: `src/protocol/{cipher,buffer,opcodes,handshake}.c`
 - Game events & builders: `src/protocol/{game_events,game_builders}.c`
 - Network: `src/network/{net,peer,transport,reliable,gamespy,master}.c`
 - Client transport (test harness side): `src/network/client_transport.c`
 - Checksum: `src/checksum/{string_hash,file_hash,hash_tables,manifest}.c`
-- Game systems: `src/game/{ship_data,ship_state,movement,combat}.c`
+- Game systems: `src/game/{ship_data,ship_state,ship_power,movement,combat,torpedo_tracker}.c`
 - Logging: `src/server/log.c`
 - Test harness helpers: `tests/test_util.h` (unit), `tests/test_harness.h` (integration)
 - Ship/projectile data: `data/vanilla-1.1/`

--- a/README.md
+++ b/README.md
@@ -41,17 +41,22 @@ All of these features work in our test harness and generate correct wire-format 
 - Power system: reactor/battery/conduit simulation, 10Hz subsystem health broadcast, sign-bit encoding
 - PythonEvent generation: subsystem damage/repair events, ship explosion events, score tracking
 - Respawn system with configurable timer and frag/time limit win conditions
+- Self-destruct system with countdown, abort, and explosion damage
+- Ship death lifecycle: destruction sequence, delete-player animation, respawn coordination
 - Chat (global and team), lobby and in-game
 - GameSpy LAN browser and internet master server registration
 - Reliable delivery with retransmit, sequencing, and fragment reassembly
 - Dynamic AI battles with seeded RNG
 - Manifest auto-detection, session summary at shutdown, graceful shutdown handling
+- Subsystem integrity validation and anticheat checks
+- Player slot identity tracking and security validation
+- Restart authorization flow
 
 ### Project facts
 
 - Ship data registry: 16 ships, 15 projectile types loaded from JSON
 - Cross-platform: builds natively on Linux and macOS, cross-compiles to Win32 via MinGW
-- 11 test suites, 226 tests, 1,184 assertions
+- 19 test suites, 290 tests, 1,369 assertions
 
 ## Quick Start
 
@@ -59,7 +64,7 @@ All of these features work in our test harness and generate correct wire-format 
 
 ```
 make all     # builds openbc-hash and openbc-server
-make test    # runs all 11 test suites
+make test    # runs all 19 test suites
 ./build/openbc-server [options]
 ```
 
@@ -67,7 +72,7 @@ make test    # runs all 11 test suites
 
 ```
 make all PLATFORM=Windows   # builds openbc-hash.exe and openbc-server.exe
-make test PLATFORM=Windows  # runs all 11 test suites (WSL2 runs .exe natively)
+make test PLATFORM=Windows  # runs all 19 test suites (WSL2 runs .exe natively)
 ```
 
 Prerequisites: a C11 compiler (`cc` on Linux/macOS, `i686-w64-mingw32-gcc` for Windows cross-compile), and Make.
@@ -137,7 +142,7 @@ src/
   network/     UDP transport, peer management, reliability, GameSpy
   protocol/    Wire codec, opcodes, handshake, game events
   server/      Entry point, configuration, logging
-tests/         11 test suites (unit + integration)
+tests/         19 test suites (unit + integration)
 tools/         CLI tools (hash manifest generator, data scraper, diagnostics)
 data/          Ship and projectile data (vanilla-1.1/)
 manifests/     Precomputed hash manifests (vanilla-1.1.json)
@@ -207,7 +212,8 @@ The base game data -- 16 ships and 15 projectile types -- ships in `data/vanilla
 - [Checksum Handshake](docs/wire-formats/checksum-handshake-protocol.md) -- Hash algorithms, 5-round checksum exchange
 - [Disconnect Flow](docs/network-flows/disconnect-flow.md) -- Player disconnect detection and cleanup
 - [Wire Format Audit](docs/network-flows/wire-format-audit.md) -- Audit of wire format implementation vs spec
-- Wire format specs: [ObjCreate](docs/wire-formats/objcreate-wire-format.md), [StateUpdate](docs/wire-formats/stateupdate-wire-format.md), [CollisionEffect](docs/wire-formats/collision-effect-wire-format.md), [Explosion](docs/wire-formats/explosion-wire-format.md)
+- Wire format specs: [ObjCreate](docs/wire-formats/objcreate-wire-format.md), [StateUpdate](docs/wire-formats/stateupdate-wire-format.md), [CollisionEffect](docs/wire-formats/collision-effect-wire-format.md), [Explosion](docs/wire-formats/explosion-wire-format.md), [DeletePlayerAnim](docs/wire-formats/delete-player-anim-wire-format.md), [DeletePlayerUI](docs/wire-formats/delete-player-ui-wire-format.md), [EventForward](docs/wire-formats/event-forward-wire-format.md), [SetPhaserLevel](docs/wire-formats/set-phaser-level-wire-format.md), [ScriptMessage](docs/wire-formats/script-message-wire-format.md)
+- [Per-Ship Subsystem Wire Format](docs/wire-formats/per-ship-subsystem-wire-format.md) -- All 16 stock ships' subsystem serialization order
 - [ObjCreate Unknown Species](docs/bugs/objcreate-unknown-species.md) -- Behavior when species index exceeds client ship table
 
 **Game Systems:**
@@ -217,10 +223,12 @@ The base game data -- 16 ships and 15 projectile types -- ships in `data/vanilla
 - [Ship Subsystems](docs/game-systems/ship-subsystems.md) -- Fixed subsystem index table, HP values, StateUpdate serialization
 - [Collision Detection](docs/game-systems/collision-detection-system.md) -- Collision damage scaling, dual damage paths
 - [Collision Shield Interaction](docs/game-systems/collision-shield-interaction.md) -- Shield absorption during collisions
+- [Self-Destruct System](docs/game-systems/self-destruct-system.md) -- Countdown, abort, explosion damage, wire events
+- [Ship Death Lifecycle](docs/game-systems/ship-death-lifecycle.md) -- Destruction sequence, delete-player animation, respawn
 - [PythonEvent Wire Format](docs/wire-formats/pythonevent-wire-format.md) -- Factory IDs, event types, subsystem and explosion events
 
 **Testing & Tools:**
-- [Test Suite](tests/README.md) -- 11 test suites, test frameworks, adding new tests
+- [Test Suite](tests/README.md) -- 19 test suites, test frameworks, adding new tests
 - [Tools](tools/README.md) -- CLI tools, data scraper, diagnostic utilities
 
 ## Contributing

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,11 +1,11 @@
 # OpenBC Test Suite
 
-11 test suites, 223 tests, 1,155 assertions. All tests cross-compile from WSL2 to Win32 and run natively.
+19 test suites, 290 tests, 1,369 assertions. All tests cross-compile from WSL2 to Win32 and run natively.
 
 ## Running Tests
 
 ```
-make test                            # all 11 suites
+make test                            # all 19 suites
 ./build/tests/test_checksum.exe      # single suite (verbose)
 ```
 
@@ -13,18 +13,26 @@ make test                            # all 11 suites
 
 | Suite | Tests | Asserts | Covers |
 |-------|------:|--------:|--------|
-| `test_protocol.c` | 69 | 362 | Wire cipher, buffer codec, CF16/CV3/CV4 compression, handshake builders |
-| `test_registry.c` | 43 | 162 | Ship data registry: 16 ships, 15 projectiles, subsystem lookup |
-| `test_gamespy.c` | 21 | 133 | GameSpy query/response, master server, LAN broadcast |
+| `test_protocol.c` | 80 | 454 | Wire cipher, buffer codec, CF16/CV3/CV4 compression, handshake builders |
+| `test_registry.c` | 49 | 197 | Ship data registry: 16 ships, 15 projectiles, subsystem lookup, power |
+| `test_gamespy.c` | 32 | 126 | GameSpy query/response, master server, LAN broadcast |
+| `test_game_builders.c` | 26 | 119 | Packet builders: settings, gameinit, mission, boot, UI, state updates |
+| `test_game_events.c` | 22 | 54 | Event parsers: torpedo, beam, explosion, chat, object create/destroy |
 | `test_checksum.c` | 21 | 44 | StringHash, FileHash, manifest validation |
-| `test_game_events.c` | 18 | 50 | Event parsers: torpedo, beam, explosion, chat, object create/destroy |
-| `test_game_builders.c` | 17 | 69 | Packet builders: settings, gameinit, mission, boot, UI |
 | `test_json.c` | 15 | 50 | JSON parser: objects, arrays, strings, numbers, nesting |
-| `test_client_transport.c` | 12 | 92 | Client transport: connect, checksum rounds, ACK, reliable delivery |
-| `test_battle.c` | 3 | 143 | Valentine's Day battle replay from real packet traces |
-| `test_dynamic_battle.c` | 3 | 41 | Seeded RNG AI battle: 3-7 ships, combat/cloak/tractor/repair |
+| `test_client_transport.c` | 12 | 93 | Client transport: connect, checksum rounds, ACK, reliable delivery |
+| `test_death_repair_burst.c` | 6 | 31 | Ship death lifecycle, repair burst handling |
+| `test_self_destruct.c` | 5 | 5 | Self-destruct countdown, abort, explosion damage |
+| `test_combat_damage.c` | 4 | 11 | Combat damage pipeline, subsystem targeting |
+| `test_player_ids.c` | 4 | 15 | Player slot ID assignment and validation |
+| `test_battle.c` | 3 | 103 | Valentine's Day battle replay from real packet traces |
+| `test_dynamic_battle.c` | 3 | 42 | Seeded RNG AI battle: 3-7 ships, combat/cloak/tractor/repair |
+| `test_subsystem_anticheat.c` | 2 | 11 | Subsystem integrity validation, anticheat checks |
+| `test_security_identity.c` | 2 | 2 | Player identity security validation |
+| `test_join_flow.c` | 2 | 2 | Join flow integration: connect through gameplay |
 | `test_networked_battle.c` | 1 | 9 | Real UDP through live server subprocess, packet trace logging |
-| **Total** | **223** | **1,155** | |
+| `test_restart_authorization.c` | 1 | 1 | Game restart authorization flow |
+| **Total** | **290** | **1,369** | |
 
 ## Test Frameworks
 
@@ -53,13 +61,19 @@ Multi-client integration harness with:
 
 ## Integration Tests
 
-Three integration tests exercise progressively more of the stack:
+Integration tests exercise progressively more of the stack:
 
-1. **`test_battle.c`** -- Replays real packet captures from the Valentine's Day battle trace. Verifies that the codec produces wire-identical output to the stock server. Covers 143 assertions across settings, gameinit, state updates, weapon fire, explosions, and object lifecycle.
+1. **`test_battle.c`** -- Replays real packet captures from the Valentine's Day battle trace. Verifies that the codec produces wire-identical output to the stock server. Covers settings, gameinit, state updates, weapon fire, explosions, and object lifecycle.
 
 2. **`test_dynamic_battle.c`** -- Spawns 3-7 AI ships with seeded RNG and runs a full battle simulation. Ships use movement, weapons (phasers + torpedoes), cloaking, tractor beams, and damage repair. Verifies combat state machine transitions and damage calculations.
 
 3. **`test_networked_battle.c`** -- Starts a real server subprocess, connects headless clients over UDP, and runs AI combat through the live network stack. Writes binary packet traces for post-mortem analysis. The most comprehensive end-to-end test.
+
+4. **`test_join_flow.c`** -- Full connection lifecycle through a live server: connect, checksum exchange, settings, gameinit, and gameplay entry.
+
+5. **`test_self_destruct.c`** -- Self-destruct system: countdown initiation, abort, explosion damage application.
+
+6. **`test_restart_authorization.c`** -- Game restart authorization flow through the server.
 
 ## Test Fixtures
 
@@ -84,4 +98,4 @@ TEST_MAIN_BEGIN()
 TEST_MAIN_END()
 ```
 
-Add the test binary to the `Makefile` test targets. Each test file compiles to its own `.exe`.
+The Makefile auto-discovers `tests/test_*.c` files -- no Makefile changes needed. Each test file compiles to its own `.exe`.


### PR DESCRIPTION
## Summary

- Update test suite counts across all docs: 11 → 19 suites, 226 → 290 tests, 1,184 → 1,369 assertions
- Add new features, docs, and source files that have been added since the last docs refresh
- Full per-suite stats refresh in tests/README.md with all 8 new test suites

## Changes

**README.md:**
- Test stats updated throughout (quick start, project facts, source tree, docs link)
- Added new features to "Implemented and tested" list: self-destruct, ship death lifecycle, subsystem anticheat, player identity security, restart authorization
- Added 7 new wire format doc links (DeletePlayerAnim, DeletePlayerUI, EventForward, SetPhaserLevel, ScriptMessage, PerShipSubsystem)
- Added 2 new game system doc links (Self-Destruct, Ship Death Lifecycle)

**CLAUDE.md:**
- Test count in project layout: 11 → 19
- Key Source Files: added server subsystem files (server_state, server_send, server_dispatch, server_stats), game files (ship_power, torpedo_tracker)
- Updated source tree descriptions for game/ and server/ directories

**AGENTS.md:**
- Test count in project structure: 11 → 19

**tests/README.md:**
- Complete stats refresh: every suite's test/assert counts updated
- Added 8 new test suites with descriptions
- Updated integration tests section with 3 new entries
- Fixed "Adding New Tests" to note Makefile auto-discovers test files

## Test plan

- [x] No code changes — docs only
- [x] All counts verified against `grep -c` on actual test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)