### PR TITLE
Echo client keepalive identity data (#101)

### DIFF
--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -2064,14 +2064,16 @@ void bc_handle_packet(const bc_addr_t *from, u8 *data, int len)
                             }
                         }
                     }
-                    /* Cache the raw keepalive payload so we can echo it back.
-                     * Stock dedi mirrors the client's identity data in its
-                     * keepalive responses (22 bytes, same format). */
-                    if (tmsg->payload_len <= (int)sizeof(peer->keepalive_data)) {
-                        memcpy(peer->keepalive_data, tmsg->payload,
-                               (size_t)tmsg->payload_len);
-                        peer->keepalive_len = tmsg->payload_len;
-                    }
+                }
+                /* Cache the raw keepalive payload so we can echo it back.
+                 * Stock dedi mirrors the client's identity data in its
+                 * keepalive responses (22 bytes, same format).  Update on
+                 * every keepalive, not just the first, so the cache stays
+                 * current throughout the session. */
+                if (tmsg->payload_len <= (int)sizeof(peer->keepalive_data)) {
+                    memcpy(peer->keepalive_data, tmsg->payload,
+                           (size_t)tmsg->payload_len);
+                    peer->keepalive_len = tmsg->payload_len;
                 }
             }
             continue;  /* Keepalives are never game data */

--- a/tests/test_protocol.c
+++ b/tests/test_protocol.c
@@ -1600,6 +1600,40 @@ TEST(outbox_keepalive)
     ASSERT_EQ_INT(parsed.msgs[0].payload_len, 0);
 }
 
+TEST(outbox_keepalive_echo)
+{
+    /* Simulate the stock dedi behavior: echo the client's 20-byte identity
+     * payload back as a type 0x00 keepalive.  The payload contains
+     * [flags:1][?:2][slot:1][ip:4][name_utf16le:12] = 20 bytes.
+     * On the wire: [0x00][totalLen=22][payload...]. */
+    u8 client_payload[20] = {
+        0x00,                   /* flags */
+        0x00, 0x00,             /* unknown */
+        0x02,                   /* slot */
+        0xC0, 0xA8, 0x01, 0x64, /* IP 192.168.1.100 */
+        'T', 0, 'e', 0, 's', 0, 't', 0, 0, 0, 0, 0  /* "Test" UTF-16LE + null */
+    };
+
+    bc_outbox_t outbox;
+    bc_outbox_init(&outbox);
+
+    ASSERT(bc_outbox_add_keepalive_data(&outbox, client_payload, 20));
+
+    u8 pkt[BC_MAX_PACKET_SIZE];
+    int len = bc_outbox_flush_to_buf(&outbox, pkt, sizeof(pkt));
+    ASSERT(len == 24);  /* 2 pkt header + 2 keepalive header + 20 payload */
+
+    /* Parse back: should be a single type 0x00 message with the payload */
+    bc_packet_t parsed;
+    ASSERT(bc_transport_parse(pkt, len, &parsed));
+    ASSERT_EQ_INT(parsed.msg_count, 1);
+    ASSERT_EQ(parsed.msgs[0].type, BC_TRANSPORT_KEEPALIVE);
+    ASSERT_EQ_INT(parsed.msgs[0].payload_len, 20);
+
+    /* Verify the payload matches what the client sent */
+    ASSERT(memcmp(parsed.msgs[0].payload, client_payload, 20) == 0);
+}
+
 /* === Direction byte tests === */
 
 TEST(direction_byte_client_encoding)
@@ -1765,6 +1799,7 @@ TEST_MAIN_BEGIN()
     RUN(outbox_empty_flush);
     RUN(outbox_reliable_seq_format);
     RUN(outbox_keepalive);
+    RUN(outbox_keepalive_echo);
 
     /* Shutdown notify */
     RUN(shutdown_notify_format);


### PR DESCRIPTION
## Summary

- Move keepalive payload caching outside the name-extraction `if` block in `server_dispatch.c` so every client keepalive updates the cache, not just the first one
- Previously the cache was only written during initial player name extraction — all subsequent keepalives were ignored, leaving the server sending empty `[0x00][0x02]` keepalives after the first echo
- Add `outbox_keepalive_echo` test verifying the 22-byte identity echo round-trip format matches stock behavior

## Test plan

- [x] `make PLATFORM=Windows test` — all 20 suites pass (test_networked_battle is pre-existing flaky)
- [x] Zero compiler warnings with `-Wall -Wextra -Wpedantic`
- [x] New `outbox_keepalive_echo` test verifies payload fidelity through outbox → flush → parse cycle
- [ ] Manual test with stock BC 1.1 client to confirm keepalive echo is received

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)