### PR TITLE
Implement ObjNotFound (0x1D) and RequestObj (0x1E) handling

### DIFF
--- a/include/openbc/game_builders.h
+++ b/include/openbc/game_builders.h
@@ -58,6 +58,10 @@ int bc_build_explosion(u8 *buf, int buf_size,
  * 5 bytes total. */
 int bc_build_destroy_obj(u8 *buf, int buf_size, i32 object_id);
 
+/* ObjNotFound: [0x1D][obj:i32]
+ * 5 bytes total. Server -> Client: object ID could not be resolved. */
+int bc_build_obj_not_found(u8 *buf, int buf_size, i32 object_id);
+
 /* Chat: [0x2C|0x2D][slot:u8][pad:3][len:u16][ascii...]
  * team=false -> 0x2C, team=true -> 0x2D. */
 int bc_build_chat(u8 *buf, int buf_size,

--- a/include/openbc/game_events.h
+++ b/include/openbc/game_events.h
@@ -137,4 +137,9 @@ bool bc_parse_set_phaser_level(const u8 *payload, int len,
  * message body.  Returns true iff the single opcode byte is 0x13. */
 bool bc_parse_host_msg(const u8 *payload, int len);
 
+/* RequestObj (0x1E) -- client requests object data.
+ * Wire: [0x1E][object_id:i32], 5 bytes total.
+ * Extracts the requested object_id into *out. */
+bool bc_parse_request_obj(const u8 *payload, int len, i32 *out);
+
 #endif /* OPENBC_GAME_EVENTS_H */

--- a/src/protocol/game_builders.c
+++ b/src/protocol/game_builders.c
@@ -108,6 +108,17 @@ int bc_build_destroy_obj(u8 *buf, int buf_size, i32 object_id)
     return (int)b.pos;
 }
 
+int bc_build_obj_not_found(u8 *buf, int buf_size, i32 object_id)
+{
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, (size_t)buf_size);
+
+    if (!bc_buf_write_u8(&b, BC_OP_OBJ_NOT_FOUND)) return -1;
+    if (!bc_buf_write_i32(&b, object_id)) return -1;
+
+    return (int)b.pos;
+}
+
 int bc_build_chat(u8 *buf, int buf_size,
                    u8 sender_slot, bool team, const char *message)
 {

--- a/src/protocol/game_events.c
+++ b/src/protocol/game_events.c
@@ -369,6 +369,28 @@ bool bc_parse_host_msg(const u8 *payload, int len)
 }
 
 /*
+ * RequestObj (opcode 0x1E)
+ *
+ * Wire format:
+ *   [0x1E][object_id:i32]
+ *
+ * Total: 5 bytes
+ */
+bool bc_parse_request_obj(const u8 *payload, int len, i32 *out)
+{
+    bc_buffer_t buf;
+    bc_buf_init(&buf, (u8 *)payload, (size_t)len);
+
+    u8 opcode;
+    if (!bc_buf_read_u8(&buf, &opcode)) return false;
+    if (opcode != BC_OP_REQUEST_OBJ) return false;
+
+    if (!bc_buf_read_i32(&buf, out)) return false;
+
+    return true;
+}
+
+/*
  * Chat / Team Chat (opcode 0x2C / 0x2D)
  *
  * Wire format:

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -1873,9 +1873,32 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
     }
 
     /* --- Request object (C->S, server responds with object data) --- */
-    case BC_OP_REQUEST_OBJ:
-        LOG_DEBUG("game", "slot=%d request object len=%d", peer_slot, payload_len);
+    case BC_OP_REQUEST_OBJ: {
+        i32 requested_id;
+        if (!bc_parse_request_obj(payload, payload_len, &requested_id)) {
+            LOG_WARN("game", "slot=%d malformed RequestObj", peer_slot);
+            break;
+        }
+
+        int owner_slot = find_peer_by_object(requested_id);
+        if (owner_slot > 0 && g_peers.peers[owner_slot].spawn_len > 0) {
+            /* Object exists -- resend its cached ObjCreateTeam */
+            bc_peer_t *owner = &g_peers.peers[owner_slot];
+            bc_queue_reliable(peer_slot, owner->spawn_payload, owner->spawn_len);
+            LOG_INFO("game", "slot=%d RequestObj 0x%08X -> resent spawn from slot %d",
+                     peer_slot, (unsigned)requested_id, owner_slot);
+        } else {
+            /* Object not found -- send ObjNotFound */
+            u8 nf_buf[8];
+            int nf_len = bc_build_obj_not_found(nf_buf, sizeof(nf_buf), requested_id);
+            if (nf_len > 0) {
+                bc_queue_reliable(peer_slot, nf_buf, nf_len);
+            }
+            LOG_INFO("game", "slot=%d RequestObj 0x%08X -> not found",
+                     peer_slot, (unsigned)requested_id);
+        }
         break;
+    }
 
     default:
         g_stats.opcodes_rejected[opcode]++;

--- a/tests/test_game_builders.c
+++ b/tests/test_game_builders.c
@@ -234,6 +234,25 @@ TEST(destroy_obj_5_bytes)
     ASSERT_EQ_INT(bc_object_id_to_slot(ev.object_id), 1);
 }
 
+/* === ObjNotFound === */
+
+TEST(obj_not_found_5_bytes)
+{
+    u8 buf[16];
+    int len = bc_build_obj_not_found(buf, sizeof(buf), bc_make_ship_id(2));
+
+    ASSERT(len == 5);
+    ASSERT_EQ(buf[0], BC_OP_OBJ_NOT_FOUND);
+    ASSERT_EQ_INT(read_i32_le(buf + 1), bc_make_ship_id(2));
+}
+
+TEST(obj_not_found_buffer_too_small)
+{
+    u8 buf[4];
+    int len = bc_build_obj_not_found(buf, sizeof(buf), bc_make_ship_id(0));
+    ASSERT_EQ_INT(len, -1);
+}
+
 /* === Chat === */
 
 TEST(chat_all)
@@ -429,6 +448,10 @@ TEST_MAIN_BEGIN()
 
     /* DestroyObject */
     RUN(destroy_obj_5_bytes);
+
+    /* ObjNotFound */
+    RUN(obj_not_found_5_bytes);
+    RUN(obj_not_found_buffer_too_small);
 
     /* Chat */
     RUN(chat_all);

--- a/tests/test_game_events.c
+++ b/tests/test_game_events.c
@@ -246,6 +246,41 @@ TEST(object_create_no_team)
     ASSERT(!hdr.has_team);
 }
 
+/* === RequestObj parser === */
+
+TEST(request_obj_happy_path)
+{
+    u8 buf[8];
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, sizeof(buf));
+    bc_buf_write_u8(&b, BC_OP_REQUEST_OBJ);
+    bc_buf_write_i32(&b, 0x3FFFFFFF + 0x40000);  /* slot 1 ship */
+
+    i32 object_id = 0;
+    ASSERT(bc_parse_request_obj(buf, (int)b.pos, &object_id));
+    ASSERT_EQ_INT(bc_object_id_to_slot(object_id), 1);
+}
+
+TEST(request_obj_truncated)
+{
+    u8 buf[2] = { BC_OP_REQUEST_OBJ, 0x00 };
+
+    i32 object_id = 0;
+    ASSERT(!bc_parse_request_obj(buf, 2, &object_id));
+}
+
+TEST(request_obj_wrong_opcode)
+{
+    u8 buf[8];
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, sizeof(buf));
+    bc_buf_write_u8(&b, BC_OP_OBJ_NOT_FOUND);  /* wrong opcode */
+    bc_buf_write_i32(&b, 0x3FFFFFFF);
+
+    i32 object_id = 0;
+    ASSERT(!bc_parse_request_obj(buf, (int)b.pos, &object_id));
+}
+
 /* === Chat parser === */
 
 static int build_chat(u8 *buf, int buf_size, u8 opcode, u8 slot,
@@ -358,6 +393,11 @@ TEST_MAIN_BEGIN()
     /* ObjectCreate */
     RUN(object_create_team);
     RUN(object_create_no_team);
+
+    /* RequestObj */
+    RUN(request_obj_happy_path);
+    RUN(request_obj_truncated);
+    RUN(request_obj_wrong_opcode);
 
     /* Chat */
     RUN(chat_happy_path);


### PR DESCRIPTION
## Summary

Implements the two missing object lifecycle opcodes from #100:

- **ObjNotFound (0x1D)** — Server→Client reliable notification when a referenced object ID cannot be resolved. Tells clients to stop sending messages to dead/stale objects. Stock traces show 36 occurrences per 33.5min session, primarily after ship deaths when pending messages reference the old object ID.
- **RequestObj (0x1E)** — Client→Server request for object data. Server looks up the object owner and resends the cached ObjCreateTeam (0x03), or replies with ObjNotFound if the object doesn't exist. Provides a safety net for object synchronization failures.

### Changes
- `bc_build_obj_not_found()` builder in game_builders (5-byte wire format: `[0x1D][object_id:i32]`)
- `bc_parse_request_obj()` parser in game_events
- Full dispatch handler in server_dispatch replacing the previous stub — resolves object ownership via `find_peer_by_object()`, resends cached spawn data or sends ObjNotFound
- 5 new unit tests covering builder/parser happy-path, truncation, wrong-opcode, and buffer overflow

## Test plan

- [x] `make PLATFORM=Windows` — zero warnings
- [x] `make PLATFORM=Windows test` — all 21 test suites pass (0 failures)
- [ ] Live test with stock BC 1.1 client: trigger ship death + respawn, verify ObjNotFound appears in server log
- [ ] Verify no regressions in join flow or combat relay

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)