### PR TITLE
Add test coverage for repair relay opcodes (closes #99)

### DIFF
--- a/tests/test_battle.c
+++ b/tests/test_battle.c
@@ -406,6 +406,7 @@ static int run_battle(void)
     {
         u8 buf[32];
 
+        /* AddToRepairList: Kirk queues subsystem 5 for repair */
         u8 repair_data[] = { 0xFF, 0xFF, 0xFF, 0x3F, 0x05, 0x00 };
         int len = bc_build_event_forward(buf, sizeof(buf),
                                           BC_OP_ADD_REPAIR_LIST,
@@ -413,6 +414,7 @@ static int run_battle(void)
         BATTLE_ASSERT(len > 0);
         BATTLE_ASSERT(test_client_send_reliable(&g_kirk, buf, len));
 
+        /* RepairPriority: Kirk reorders repair queue */
         u8 priority_data[] = { 0xFF, 0xFF, 0xFF, 0x3F, 0x05, 0x01 };
         len = bc_build_event_forward(buf, sizeof(buf),
                                       BC_OP_REPAIR_PRIORITY,
@@ -422,14 +424,34 @@ static int run_battle(void)
 
         Sleep(200);
 
+        /* Sep receives both — verify byte-identical payload */
         int msg_len = 0;
         const u8 *msg;
         msg = test_client_expect_opcode(&g_sep, BC_OP_ADD_REPAIR_LIST,
                                          &msg_len, TIMEOUT);
         BATTLE_ASSERT(msg != NULL);
+        BATTLE_ASSERT(msg_len == 1 + (int)sizeof(repair_data));
+        BATTLE_ASSERT(msg[0] == BC_OP_ADD_REPAIR_LIST);
+        BATTLE_ASSERT(memcmp(msg + 1, repair_data, sizeof(repair_data)) == 0);
+
         msg = test_client_expect_opcode(&g_sep, BC_OP_REPAIR_PRIORITY,
                                          &msg_len, TIMEOUT);
         BATTLE_ASSERT(msg != NULL);
+        BATTLE_ASSERT(msg_len == 1 + (int)sizeof(priority_data));
+        BATTLE_ASSERT(msg[0] == BC_OP_REPAIR_PRIORITY);
+        BATTLE_ASSERT(memcmp(msg + 1, priority_data,
+                             sizeof(priority_data)) == 0);
+
+        /* Cady also receives both (N-1 relay) */
+        msg = test_client_expect_opcode(&g_cady, BC_OP_ADD_REPAIR_LIST,
+                                         &msg_len, TIMEOUT);
+        BATTLE_ASSERT(msg != NULL);
+        BATTLE_ASSERT(msg[0] == BC_OP_ADD_REPAIR_LIST);
+
+        msg = test_client_expect_opcode(&g_cady, BC_OP_REPAIR_PRIORITY,
+                                         &msg_len, TIMEOUT);
+        BATTLE_ASSERT(msg != NULL);
+        BATTLE_ASSERT(msg[0] == BC_OP_REPAIR_PRIORITY);
     }
 
     /* === Phase 9: COLLISION === */

--- a/tests/test_game_builders.c
+++ b/tests/test_game_builders.c
@@ -419,6 +419,39 @@ TEST(event_forward_generic)
     ASSERT_EQ(buf[3], 0xCC);
 }
 
+TEST(event_forward_add_repair_list)
+{
+    u8 data[] = { 0xFF, 0xFF, 0xFF, 0x3F, 0x05, 0x00 };
+    u8 buf[32];
+    int len = bc_build_event_forward(buf, sizeof(buf),
+                                      BC_OP_ADD_REPAIR_LIST, data, 6);
+
+    ASSERT(len == 7);
+    ASSERT_EQ(buf[0], BC_OP_ADD_REPAIR_LIST);
+    ASSERT(memcmp(buf + 1, data, 6) == 0);
+}
+
+TEST(event_forward_repair_priority)
+{
+    u8 data[] = { 0xFF, 0xFF, 0xFF, 0x3F, 0x05, 0x01 };
+    u8 buf[32];
+    int len = bc_build_event_forward(buf, sizeof(buf),
+                                      BC_OP_REPAIR_PRIORITY, data, 6);
+
+    ASSERT(len == 7);
+    ASSERT_EQ(buf[0], BC_OP_REPAIR_PRIORITY);
+    ASSERT(memcmp(buf + 1, data, 6) == 0);
+}
+
+TEST(event_forward_buffer_overflow)
+{
+    u8 data[] = { 0xAA, 0xBB, 0xCC };
+    u8 buf[3]; /* too small for opcode + 3 bytes */
+    int len = bc_build_event_forward(buf, sizeof(buf),
+                                      BC_OP_ADD_REPAIR_LIST, data, 3);
+    ASSERT(len == -1);
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -471,4 +504,7 @@ TEST_MAIN_BEGIN()
 
     /* Event forward */
     RUN(event_forward_generic);
+    RUN(event_forward_add_repair_list);
+    RUN(event_forward_repair_priority);
+    RUN(event_forward_buffer_overflow);
 TEST_MAIN_END()


### PR DESCRIPTION
## Summary

- Confirmed both `AddToRepairList` (0x0B) and `RepairPriority` (0x11) are **already relayed** correctly in `server_dispatch.c` — no code changes needed
- Enhanced Phase 8 (Repair) in `test_battle.c` with **byte-identical payload verification** (matching Phase 9/Collision pattern) and **multi-receiver checks** (verifies Cady also receives, not just Sep)
- Added 3 dedicated unit tests in `test_game_builders.c`: builder output for each opcode + buffer overflow guard

## Test plan

- [x] `test_game_builders.exe` — 29/29 pass (3 new tests)
- [x] `test_battle.exe` — 3/3 pass (enhanced Phase 8 assertions)
- [x] Full suite — 21/21 pass, 0 warnings on new test code

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)