### PR TITLE
Add DeletePlayerAnim (0x18) parser and disconnect notification test

### DIFF
--- a/include/openbc/game_events.h
+++ b/include/openbc/game_events.h
@@ -142,4 +142,15 @@ bool bc_parse_host_msg(const u8 *payload, int len);
  * Extracts the requested object_id into *out. */
 bool bc_parse_request_obj(const u8 *payload, int len, i32 *out);
 
+/* DeletePlayerAnim (0x18) -- player join/leave floating notification.
+ * Wire: [0x18][name_len:u16 LE][name:bytes]
+ * Extracts the player name (not null-terminated in wire format). */
+typedef struct {
+    char player_name[64];
+    int  name_len;
+} bc_delete_player_anim_event_t;
+
+bool bc_parse_delete_player_anim(const u8 *payload, int len,
+                                  bc_delete_player_anim_event_t *out);
+
 #endif /* OPENBC_GAME_EVENTS_H */

--- a/src/protocol/game_events.c
+++ b/src/protocol/game_events.c
@@ -433,3 +433,43 @@ bool bc_parse_chat_message(const u8 *payload, int len, bc_chat_event_t *out)
 
     return true;
 }
+
+/*
+ * DeletePlayerAnim (opcode 0x18)
+ *
+ * Wire format:
+ *   [0x18][name_len:u16 LE][name:bytes]
+ *
+ * Minimum: 3 bytes (empty name, though builder rejects empty names)
+ */
+bool bc_parse_delete_player_anim(const u8 *payload, int len,
+                                  bc_delete_player_anim_event_t *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    bc_buffer_t buf;
+    bc_buf_init(&buf, (u8 *)payload, (size_t)len);
+
+    u8 opcode;
+    if (!bc_buf_read_u8(&buf, &opcode)) return false;
+    if (opcode != BC_OP_DELETE_PLAYER_ANIM) return false;
+
+    u16 name_len;
+    if (!bc_buf_read_u16(&buf, &name_len)) return false;
+
+    /* Clamp to output buffer size (leave room for null terminator) */
+    int copy_len = (int)name_len;
+    if (copy_len > (int)sizeof(out->player_name) - 1)
+        copy_len = (int)sizeof(out->player_name) - 1;
+    if ((size_t)copy_len > bc_buf_remaining(&buf))
+        return false;  /* Truncated payload */
+
+    if (copy_len > 0) {
+        if (!bc_buf_read_bytes(&buf, (u8 *)out->player_name, (size_t)copy_len))
+            return false;
+    }
+    out->player_name[copy_len] = '\0';
+    out->name_len = copy_len;
+
+    return true;
+}

--- a/tests/test_game_events.c
+++ b/tests/test_game_events.c
@@ -1,5 +1,6 @@
 #include "test_util.h"
 #include "openbc/game_events.h"
+#include "openbc/handshake.h"
 #include "openbc/buffer.h"
 #include "openbc/opcodes.h"
 #include <string.h>
@@ -364,6 +365,69 @@ TEST(host_msg_extra_bytes)
     ASSERT(bc_parse_host_msg(buf, 4));
 }
 
+/* === DeletePlayerAnim (0x18) parser === */
+
+TEST(delete_player_anim_happy_path)
+{
+    /* Build a valid 0x18 message: [0x18][len:u16 LE]["Cady"] */
+    u8 buf[] = { 0x18, 0x04, 0x00, 'C', 'a', 'd', 'y' };
+    bc_delete_player_anim_event_t ev;
+    ASSERT(bc_parse_delete_player_anim(buf, sizeof(buf), &ev));
+    ASSERT_EQ_INT(ev.name_len, 4);
+    ASSERT(memcmp(ev.player_name, "Cady", 4) == 0);
+    ASSERT_EQ(ev.player_name[4], '\0');  /* null-terminated */
+}
+
+TEST(delete_player_anim_long_name)
+{
+    /* 16-char name */
+    u8 buf[3 + 16];
+    buf[0] = 0x18;
+    buf[1] = 16;
+    buf[2] = 0;
+    memcpy(buf + 3, "SixteenCharName!", 16);
+    bc_delete_player_anim_event_t ev;
+    ASSERT(bc_parse_delete_player_anim(buf, sizeof(buf), &ev));
+    ASSERT_EQ_INT(ev.name_len, 16);
+    ASSERT(memcmp(ev.player_name, "SixteenCharName!", 16) == 0);
+}
+
+TEST(delete_player_anim_truncated)
+{
+    /* Name length says 4 but only 2 bytes available */
+    u8 buf[] = { 0x18, 0x04, 0x00, 'A', 'B' };
+    bc_delete_player_anim_event_t ev;
+    ASSERT(!bc_parse_delete_player_anim(buf, sizeof(buf), &ev));
+}
+
+TEST(delete_player_anim_wrong_opcode)
+{
+    u8 buf[] = { 0x14, 0x02, 0x00, 'A', 'B' };
+    bc_delete_player_anim_event_t ev;
+    ASSERT(!bc_parse_delete_player_anim(buf, sizeof(buf), &ev));
+}
+
+TEST(delete_player_anim_too_short)
+{
+    /* Just the opcode byte -- missing name_len */
+    u8 buf[] = { 0x18 };
+    bc_delete_player_anim_event_t ev;
+    ASSERT(!bc_parse_delete_player_anim(buf, 1, &ev));
+}
+
+TEST(delete_player_anim_roundtrip)
+{
+    /* Build with bc_delete_player_anim_build, parse with bc_parse_delete_player_anim */
+    u8 wire[128];
+    int wire_len = bc_delete_player_anim_build(wire, sizeof(wire), "TestPlayer");
+    ASSERT(wire_len > 0);
+
+    bc_delete_player_anim_event_t ev;
+    ASSERT(bc_parse_delete_player_anim(wire, wire_len, &ev));
+    ASSERT_EQ_INT(ev.name_len, 10);
+    ASSERT(strcmp(ev.player_name, "TestPlayer") == 0);
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -409,4 +473,12 @@ TEST_MAIN_BEGIN()
     RUN(host_msg_wrong_opcode);
     RUN(host_msg_empty);
     RUN(host_msg_extra_bytes);
+
+    /* DeletePlayerAnim (0x18) */
+    RUN(delete_player_anim_happy_path);
+    RUN(delete_player_anim_long_name);
+    RUN(delete_player_anim_truncated);
+    RUN(delete_player_anim_wrong_opcode);
+    RUN(delete_player_anim_too_short);
+    RUN(delete_player_anim_roundtrip);
 TEST_MAIN_END()

--- a/tests/test_join_flow.c
+++ b/tests/test_join_flow.c
@@ -1,15 +1,20 @@
 /*
  * Join Flow Test -- verifies DeletePlayerUI (0x17) is sent to the
- * joining player during the NewPlayerInGame response sequence.
+ * joining player during the NewPlayerInGame response sequence, and
+ * DeletePlayerAnim (0x18) is sent to remaining players on disconnect.
  *
  * Issue #59: stock server sends 0x17 after NewPlayerInGame (0x2A)
  * to add the joining player to the engine's internal player list.
  * Without it, the scoreboard UI cannot display any players.
+ *
+ * Issue #102: stock server sends 0x18 as part of the disconnect
+ * cleanup sequence to display "Player X has left" floating text.
  */
 
 #include "test_util.h"
 #include "test_harness.h"
 #include "openbc/game_builders.h"
+#include "openbc/game_events.h"
 #include "openbc/opcodes.h"
 #include "openbc/handshake.h"
 
@@ -308,7 +313,113 @@ cleanup2:
 #undef CHECK
 }
 
+/*
+ * Verify the disconnect cleanup sequence: when a player disconnects,
+ * remaining players receive DeletePlayerUI (0x17) with PLAYER_REMOVED
+ * and DeletePlayerAnim (0x18) with the departing player's name.
+ *
+ * Issue #102: the stock server sends 0x14 + 0x17 + 0x18 on disconnect.
+ */
+TEST(disconnect_sends_delete_player_anim)
+{
+    bool net_ok = false;
+    bool srv_ok = false;
+    bool cli1_ok = false;
+    bool cli2_ok = false;
+    int fail = 0;
+
+    bc_test_server_t srv;
+    bc_test_client_t cli1, cli2;
+    memset(&srv, 0, sizeof(srv));
+    memset(&cli1, 0, sizeof(cli1));
+    memset(&cli2, 0, sizeof(cli2));
+
+#define CHECK(cond) do { \
+    if (!(cond)) { \
+        printf("FAIL\n    %s:%d: %s\n", __FILE__, __LINE__, #cond); \
+        fail++; \
+        goto cleanup3; \
+    } \
+} while (0)
+
+    CHECK(bc_net_init());
+    net_ok = true;
+
+    CHECK(test_server_start(&srv, JF_PORT + 2, MANIFEST_PATH));
+    srv_ok = true;
+
+    /* Connect first client (will remain connected) */
+    CHECK(test_client_connect(&cli1, JF_PORT + 2, "Survivor", 0, GAME_DIR));
+    cli1_ok = true;
+    Sleep(100);
+    test_client_drain(&cli1, 500);
+
+    /* Connect second client (will disconnect) */
+    CHECK(test_client_connect(&cli2, JF_PORT + 2, "Leaver", 0, GAME_DIR));
+    cli2_ok = true;
+    Sleep(100);
+
+    /* Drain the join notification from cli1 (0x17 for cli2 joining) */
+    test_client_drain(&cli1, 500);
+
+    /* Disconnect cli2 -- server should send cleanup notifications to cli1 */
+    test_client_disconnect(&cli2);
+    cli2_ok = false;
+    Sleep(200);  /* Give server time to process disconnect */
+
+    /* cli1 should receive DeletePlayerUI (0x17) with PLAYER_REMOVED */
+    bool got_delete_ui = false;
+    bool got_delete_anim = false;
+    u8 anim_payload[128];
+    int anim_len = 0;
+
+    u32 start = bc_ms_now();
+    while ((int)(bc_ms_now() - start) < 3000) {
+        int msg_len = 0;
+        const u8 *msg = test_client_recv_msg(&cli1, &msg_len, 200);
+        if (!msg) continue;
+
+        if (msg_len > 0 && msg[0] == BC_OP_DELETE_PLAYER_UI) {
+            /* Verify it's a PLAYER_REMOVED event */
+            if (msg_len >= 9) {
+                i32 event_code = read_i32_le(msg + 5);
+                if (event_code == (i32)BC_EVENT_PLAYER_REMOVED)
+                    got_delete_ui = true;
+            }
+        }
+
+        if (msg_len > 0 && msg[0] == BC_OP_DELETE_PLAYER_ANIM) {
+            got_delete_anim = true;
+            anim_len = msg_len < (int)sizeof(anim_payload)
+                     ? msg_len : (int)sizeof(anim_payload);
+            memcpy(anim_payload, msg, (size_t)anim_len);
+        }
+
+        if (got_delete_ui && got_delete_anim) break;
+    }
+
+    CHECK(got_delete_ui);
+    CHECK(got_delete_anim);
+
+    /* Parse the DeletePlayerAnim and verify the player name */
+    bc_delete_player_anim_event_t ev;
+    CHECK(bc_parse_delete_player_anim(anim_payload, anim_len, &ev));
+    CHECK(ev.name_len == 6);  /* "Leaver" */
+    CHECK(strcmp(ev.player_name, "Leaver") == 0);
+
+cleanup3:
+    if (cli2_ok) test_client_disconnect(&cli2);
+    if (cli1_ok) test_client_disconnect(&cli1);
+    Sleep(100);
+    if (srv_ok) test_server_stop(&srv);
+    if (net_ok) bc_net_shutdown();
+    ASSERT(fail == 0);
+
+#undef CHECK
+}
+
 TEST_MAIN_BEGIN()
     RUN(join_sends_delete_player_ui_to_self);
     RUN(join_sends_delete_player_ui_to_others);
+    RUN(disconnect_sends_delete_player_anim);
 TEST_MAIN_END()


### PR DESCRIPTION
## Summary
Closes #102.

- Adds `bc_parse_delete_player_anim()` parser to `game_events.c/h` for parsing opcode 0x18 messages (player join/leave floating text notification)
- Adds 6 unit tests for the parser: happy path, long name, truncated payload, wrong opcode, too short, and builder-parser roundtrip
- Adds integration test `disconnect_sends_delete_player_anim` to `test_join_flow.c` that verifies the full disconnect cleanup sequence sends 0x18 with the departing player's name to remaining clients

The builder (`bc_delete_player_anim_build`) and disconnect send logic already existed in `handshake.c` and `server_handshake.c`. This PR completes the implementation by adding the parser and test coverage.

## Test plan
- [x] `test_game_events` — 31/31 pass (6 new DeletePlayerAnim parser tests)
- [x] `test_join_flow` — 3/3 pass (1 new disconnect notification test)
- [x] Zero warnings on build with `-Wall -Wextra -Wpedantic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)