### PR TITLE
Fix StateUpdate downstream authority/cadence mismatch

### DIFF
--- a/include/openbc/game_events.h
+++ b/include/openbc/game_events.h
@@ -86,6 +86,7 @@ typedef struct {
     f32 game_time;
     u8  dirty;
     f32 pos_x, pos_y, pos_z;   /* valid when dirty & 0x01 */
+    f32 delta_x, delta_y, delta_z; /* valid when dirty & 0x02 */
     f32 fwd_x, fwd_y, fwd_z;   /* valid when dirty & 0x04 */
     f32 up_x,  up_y,  up_z;    /* valid when dirty & 0x08 */
     f32 speed;                  /* valid when dirty & 0x10 */

--- a/include/openbc/ship_power.h
+++ b/include/openbc/ship_power.h
@@ -27,4 +27,17 @@ void bc_ship_power_tick(bc_ship_state_t *ship,
                         const bc_ship_class_t *cls,
                         f32 dt);
 
+/* Apply remote power allocation values from an incoming StateUpdate (0x1C)
+ * subsystem block (dirty flag 0x20) to server ship state.
+ *
+ * This reads only the power allocation/on-off intent for Powered entries.
+ * Health bytes are consumed for stream alignment but not applied.
+ *
+ * Returns number of powered entries updated, or 0 if no applicable 0x20 block
+ * is present/usable in the payload. */
+int bc_ship_apply_remote_power_state(const u8 *state_update,
+                                     int state_update_len,
+                                     const bc_ship_class_t *cls,
+                                     bc_ship_state_t *ship);
+
 #endif /* OPENBC_SHIP_POWER_H */

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -21,6 +21,7 @@
 #include "openbc/combat.h"
 #include "openbc/torpedo_tracker.h"
 #include "openbc/game_builders.h"
+#include "openbc/buffer.h"
 #include "openbc/config.h"
 #include "openbc/log.h"
 #include "openbc/module_loader.h"
@@ -117,6 +118,50 @@ static bc_log_level_t parse_log_level(const char *str)
     if (strcmp(str, "trace") == 0) return LOG_TRACE;
     fprintf(stderr, "Unknown log level: %s (using info)\n", str);
     return LOG_INFO;
+}
+
+/* Build a server-shaped downstream StateUpdate (dirty=0x3D) by combining
+ * the server-tracked movement snapshot with a prebuilt 0x20 subsystem block.
+ * health_pkt must be a valid 0x1C packet with dirty=0x20. */
+static int build_mixed_stateupdate_remote(const bc_ship_state_t *ship,
+                                          f32 game_time,
+                                          const u8 *health_pkt,
+                                          int health_len,
+                                          u8 *out,
+                                          int out_size)
+{
+    if (!ship || !health_pkt || health_len <= 10 || !out || out_size <= 0)
+        return -1;
+    if (health_pkt[0] != BC_OP_STATE_UPDATE)
+        return -1;
+    if (health_pkt[9] != BC_DIRTY_SUBSYSTEM_STATES)
+        return -1;
+
+    const u8 *health_data = health_pkt + 10;
+    int health_data_len = health_len - 10;
+
+    u8 fields[256];
+    bc_buffer_t fb;
+    bc_buf_init(&fb, fields, sizeof(fields));
+
+    if (!bc_buf_write_f32(&fb, ship->pos.x)) return -1;
+    if (!bc_buf_write_f32(&fb, ship->pos.y)) return -1;
+    if (!bc_buf_write_f32(&fb, ship->pos.z)) return -1;
+    if (!bc_buf_write_bit(&fb, false)) return -1; /* no hash payload */
+    if (!bc_buf_write_cv3(&fb, ship->fwd.x, ship->fwd.y, ship->fwd.z)) return -1;
+    if (!bc_buf_write_cv3(&fb, ship->up.x, ship->up.y, ship->up.z)) return -1;
+    if (!bc_buf_write_cf16(&fb, ship->speed)) return -1;
+    if (!bc_buf_write_bytes(&fb, health_data, (size_t)health_data_len)) return -1;
+
+    return bc_build_state_update(
+        out, out_size,
+        ship->object_id, game_time,
+        (u8)(BC_DIRTY_POSITION_ABS |
+             BC_DIRTY_ORIENT_FWD |
+             BC_DIRTY_ORIENT_UP |
+             BC_DIRTY_SPEED |
+             BC_DIRTY_SUBSYSTEM_STATES),
+        fields, (int)fb.pos);
 }
 
 static bool read_small_text_file(const char *path, char *out, size_t out_size)
@@ -852,10 +897,12 @@ int main(int argc, char **argv)
                 }
             }
 
-            /* Health broadcast: every 3 ticks (~100ms = 10 Hz), send 0x20 StateUpdate.
-             * Stock dedi sends at ~10 Hz.  Uses hierarchical round-robin with
-             * 10-byte budget per tick.  Owner gets is_own_ship=true (no power_pct
-             * bytes in Powered entries), remote observers get is_own_ship=false. */
+            /* Downstream StateUpdate broadcast: every 3 ticks (~100ms = 10 Hz).
+             *
+             * Owner lane: send subsystem-only 0x20 (no power bytes for own ship).
+             * Remote lanes: send mixed 0x3D (position/orientation/speed + 0x20)
+             * so downstream stays server-shaped instead of relaying raw owner
+             * payloads. */
             if (g_registry_loaded && (tick_counter % 3 == 0)) {
                 for (int i = 1; i < BC_MAX_PLAYERS; i++) {
                     bc_peer_t *p = &g_peers.peers[i];
@@ -882,6 +929,16 @@ int main(int argc, char **argv)
                         p->subsys_rr_idx, &rmt_next, false,
                         hbuf_rmt, sizeof(hbuf_rmt));
 
+                    /* Build mixed downstream packet for remote observers. */
+                    u8 mixed_rmt[256];
+                    int mixed_rmt_len = -1;
+                    if (hlen_rmt > 0) {
+                        mixed_rmt_len = build_mixed_stateupdate_remote(
+                            &p->ship, g_game_time,
+                            hbuf_rmt, hlen_rmt,
+                            mixed_rmt, sizeof(mixed_rmt));
+                    }
+
                     /* Advance cursor using the owner version (smaller budget,
                      * may cover fewer entries -- that's fine, the remote
                      * version just sends more data this tick). */
@@ -893,7 +950,10 @@ int main(int argc, char **argv)
                         if (g_peers.peers[j].state < PEER_LOBBY) continue;
                         if (j == i && hlen_own > 0) {
                             bc_queue_unreliable(j, hbuf_own, hlen_own);
+                        } else if (j != i && mixed_rmt_len > 0) {
+                            bc_queue_unreliable(j, mixed_rmt, mixed_rmt_len);
                         } else if (j != i && hlen_rmt > 0) {
+                            /* Fallback to 0x20-only if mixed build fails. */
                             bc_queue_unreliable(j, hbuf_rmt, hlen_rmt);
                         }
                     }

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -820,6 +820,65 @@ bool bc_torpedo_target_pos(i32 target_id, bc_vec3_t *out_pos,
     return true;
 }
 
+/* Handle inbound owner StateUpdate (0x1C) as server input only.
+ * Downstream 0x1C stream is generated server-side in main.c. */
+static void handle_state_update_input(int peer_slot, bc_peer_t *peer,
+                                      const u8 *payload, int payload_len)
+{
+    if (g_registry_loaded && peer->has_ship) {
+        const bc_ship_class_t *cls =
+            bc_registry_get_ship(&g_registry, peer->class_index);
+        bc_state_update_t su;
+        if (bc_parse_state_update(payload, payload_len, &su)) {
+            /* Track position */
+            if (su.dirty & 0x01) {
+                peer->ship.pos.x = su.pos_x;
+                peer->ship.pos.y = su.pos_y;
+                peer->ship.pos.z = su.pos_z;
+            } else if (su.dirty & 0x02) {
+                peer->ship.pos.x += su.delta_x;
+                peer->ship.pos.y += su.delta_y;
+                peer->ship.pos.z += su.delta_z;
+            }
+            if (su.dirty & 0x04) {
+                peer->ship.fwd.x = su.fwd_x;
+                peer->ship.fwd.y = su.fwd_y;
+                peer->ship.fwd.z = su.fwd_z;
+            }
+            if (su.dirty & 0x08) {
+                peer->ship.up.x = su.up_x;
+                peer->ship.up.y = su.up_y;
+                peer->ship.up.z = su.up_z;
+            }
+            if (su.dirty & 0x10) {
+                peer->ship.speed = su.speed;
+            }
+
+            /* Power percentages/on-off intent are carried inside inbound
+             * 0x20 subsystem blocks for remote ships. Apply to server ship
+             * state so downstream 0x20/0x3x broadcasts stay converged. */
+            if (cls) {
+                int updates = bc_ship_apply_remote_power_state(
+                    payload, payload_len, cls, &peer->ship);
+                if (updates > 0) {
+                    LOG_TRACE("power", "slot=%d applied %d remote power entries",
+                              peer_slot, updates);
+                }
+            }
+        } else {
+            LOG_DEBUG("state", "slot=%d malformed StateUpdate dropped",
+                      peer_slot);
+        }
+    } else {
+        /* Server is authoritative for downstream 0x1C shape/cadence.
+         * Never forward owner payload bytes verbatim. */
+        if (payload_len > 0 && payload[0] == BC_OP_STATE_UPDATE) {
+            LOG_TRACE("state", "slot=%d StateUpdate absorbed (no registry/ship)",
+                      peer_slot);
+        }
+    }
+}
+
 /* --- Game message dispatch --- */
 
 static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
@@ -1178,50 +1237,11 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
         break;
     }
 
-    /* --- StateUpdate: track position + relay (strip server-authoritative flags) --- */
-    case BC_OP_STATE_UPDATE: {
-        if (g_registry_loaded && peer->has_ship) {
-            bc_state_update_t su;
-            if (bc_parse_state_update(payload, payload_len, &su)) {
-                /* Track position */
-                if (su.dirty & 0x01) {
-                    peer->ship.pos.x = su.pos_x;
-                    peer->ship.pos.y = su.pos_y;
-                    peer->ship.pos.z = su.pos_z;
-                }
-                if (su.dirty & 0x04) {
-                    peer->ship.fwd.x = su.fwd_x;
-                    peer->ship.fwd.y = su.fwd_y;
-                    peer->ship.fwd.z = su.fwd_z;
-                }
-                if (su.dirty & 0x08) {
-                    peer->ship.up.x = su.up_x;
-                    peer->ship.up.y = su.up_y;
-                    peer->ship.up.z = su.up_z;
-                }
-                if (su.dirty & 0x10) {
-                    peer->ship.speed = su.speed;
-                }
-
-                /* Strip server-authoritative flag 0x20 (subsystem health).
-                 * 0x80 (weapon state) is CLIENT-authoritative and must be relayed.
-                 * The SUBSYSTEMS/WEAPONS flag split is ~96% direction-correlated
-                 * (not 100%): in stock BC, the host's own ship can send 0x80 in
-                 * the server→client direction. On our dedicated server there is no
-                 * host-player ship, so dropping pure 0x20 packets from clients
-                 * is still correct. */
-                if (su.dirty == 0x20) {
-                    /* Pure subsystem health update from client -- drop it.
-                     * The server is authoritative for subsystem health. */
-                    LOG_DEBUG("cheat", "slot=%d StateUpdate 0x20 suppressed",
-                              peer_slot);
-                    break;
-                }
-            }
-        }
-        bc_relay_to_others(peer_slot, payload, payload_len, false);
+    /* --- StateUpdate: owner input only (server builds downstream stream) --- */
+    case BC_OP_STATE_UPDATE:
+        handle_state_update_input(peer_slot, peer, payload, payload_len);
+        /* Always absorb incoming 0x1C; downstream is generated server-side. */
         break;
-    }
 
     /* --- Object creation: relay + cache + init server ship state --- */
     case BC_OP_OBJ_CREATE_TEAM:

--- a/src/shared/game/ship_power.c
+++ b/src/shared/game/ship_power.c
@@ -1,6 +1,7 @@
 #include "openbc/ship_power.h"
 #include "openbc/buffer.h"
 #include "openbc/game_builders.h"
+#include "openbc/opcodes.h"
 
 /* --- Hierarchical health serializer (flag 0x20) --- */
 
@@ -110,6 +111,144 @@ int bc_ship_build_health_update(const bc_ship_state_t *ship,
     return bc_build_state_update(buf, buf_size,
                                   ship->object_id, game_time, 0x20,
                                   field, (int)fb.pos);
+}
+
+static bool skip_stateupdate_prefix_to_subsystems(bc_buffer_t *buf, u8 *dirty_out)
+{
+    u8 opcode;
+    i32 object_id;
+    f32 game_time;
+    u8 dirty;
+
+    if (!bc_buf_read_u8(buf, &opcode)) return false;
+    if (opcode != BC_OP_STATE_UPDATE) return false;
+    if (!bc_buf_read_i32(buf, &object_id)) return false;
+    if (!bc_buf_read_f32(buf, &game_time)) return false;
+    if (!bc_buf_read_u8(buf, &dirty)) return false;
+    (void)object_id;
+    (void)game_time;
+    if (dirty_out) *dirty_out = dirty;
+
+    if (dirty & BC_DIRTY_POSITION_ABS) {
+        bool has_hash = false;
+        u16 hash16;
+        f32 x, y, z;
+        if (!bc_buf_read_f32(buf, &x)) return false;
+        if (!bc_buf_read_f32(buf, &y)) return false;
+        if (!bc_buf_read_f32(buf, &z)) return false;
+        if (!bc_buf_read_bit(buf, &has_hash)) return false;
+        if (has_hash) {
+            if (!bc_buf_read_u16(buf, &hash16)) return false;
+        }
+    }
+    if (dirty & BC_DIRTY_POSITION_DELTA) {
+        f32 dx, dy, dz;
+        if (!bc_buf_read_cv4(buf, &dx, &dy, &dz)) return false;
+    }
+    if (dirty & BC_DIRTY_ORIENT_FWD) {
+        f32 fx, fy, fz;
+        if (!bc_buf_read_cv3(buf, &fx, &fy, &fz)) return false;
+    }
+    if (dirty & BC_DIRTY_ORIENT_UP) {
+        f32 ux, uy, uz;
+        if (!bc_buf_read_cv3(buf, &ux, &uy, &uz)) return false;
+    }
+    if (dirty & BC_DIRTY_SPEED) {
+        f32 speed;
+        if (!bc_buf_read_cf16(buf, &speed)) return false;
+    }
+
+    return true;
+}
+
+int bc_ship_apply_remote_power_state(const u8 *state_update,
+                                     int state_update_len,
+                                     const bc_ship_class_t *cls,
+                                     bc_ship_state_t *ship)
+{
+    if (!state_update || state_update_len <= 0 || !cls || !ship)
+        return 0;
+
+    const bc_ss_list_t *sl = &cls->ser_list;
+    if (sl->count <= 0) return 0;
+
+    bc_buffer_t buf;
+    bc_buf_init(&buf, (u8 *)state_update, (size_t)state_update_len);
+
+    u8 dirty = 0;
+    if (!skip_stateupdate_prefix_to_subsystems(&buf, &dirty))
+        return 0;
+
+    if (!(dirty & BC_DIRTY_SUBSYSTEM_STATES))
+        return 0;
+
+    /* The 0x20 block has no explicit length field. Keep parsing constrained
+     * to cases where no unknown variable-length tail (0x80 weapon block) can
+     * follow it in the same packet. */
+    if (dirty & BC_DIRTY_WEAPON_STATES)
+        return 0;
+
+    if (dirty & BC_DIRTY_CLOAK_STATE)
+        return 0;
+
+    u8 start_idx;
+    if (!bc_buf_read_u8(&buf, &start_idx))
+        return 0;
+
+    int cursor = (int)start_idx;
+    if (cursor < 0 || cursor >= sl->count)
+        cursor = 0;
+
+    int updated = 0;
+
+    while (bc_buf_remaining(&buf) > 0) {
+        const bc_ss_entry_t *e = &sl->entries[cursor];
+        u8 condition_byte;
+
+        if (!bc_buf_read_u8(&buf, &condition_byte))
+            break;
+
+        for (int c = 0; c < e->child_count; c++) {
+            if (!bc_buf_read_u8(&buf, &condition_byte))
+                return updated;
+        }
+
+        if (e->format == BC_SS_FORMAT_POWERED) {
+            bool has_power_data = false;
+            if (!bc_buf_read_bit(&buf, &has_power_data))
+                return updated;
+
+            if (has_power_data) {
+                u8 raw_pct;
+                if (!bc_buf_read_u8(&buf, &raw_pct))
+                    return updated;
+
+                i8 signed_pct = (i8)raw_pct;
+                bool enabled = signed_pct > 0;
+                u8 pct = enabled ? raw_pct : (u8)(-signed_pct);
+
+                if (signed_pct == 0) {
+                    enabled = false;
+                    pct = 0;
+                }
+
+                ship->power_pct[cursor] = pct;
+                ship->subsys_enabled[cursor] = enabled;
+                updated++;
+            }
+        } else if (e->format == BC_SS_FORMAT_POWER) {
+            /* Battery percentages follow the power entry; consume for
+             * stream alignment but keep server battery authority local. */
+            u8 skip;
+            if (!bc_buf_read_u8(&buf, &skip)) return updated;
+            if (!bc_buf_read_u8(&buf, &skip)) return updated;
+        }
+
+        cursor++;
+        if (cursor >= sl->count) cursor = 0;
+    }
+
+    return updated;
 }
 
 /* --- Reactor / power simulation --- */

--- a/src/shared/protocol/game_events.c
+++ b/src/shared/protocol/game_events.c
@@ -298,14 +298,20 @@ bool bc_parse_state_update(const u8 *payload, int len,
 
     /* Parse fields in order of dirty flag bits */
     if (out->dirty & 0x01) {
+        bool has_hash = false;
+        u16 hash16;
         if (!bc_buf_read_f32(&buf, &out->pos_x)) return false;
         if (!bc_buf_read_f32(&buf, &out->pos_y)) return false;
         if (!bc_buf_read_f32(&buf, &out->pos_z)) return false;
+        if (!bc_buf_read_bit(&buf, &has_hash)) return false;
+        if (has_hash) {
+            if (!bc_buf_read_u16(&buf, &hash16)) return false;
+            (void)hash16;
+        }
     }
     if (out->dirty & 0x02) {
-        /* Delta position (cv4) -- skip 5 bytes, we only track absolute */
-        f32 dx, dy, dz;
-        if (!bc_buf_read_cv4(&buf, &dx, &dy, &dz)) return false;
+        if (!bc_buf_read_cv4(&buf, &out->delta_x, &out->delta_y, &out->delta_z))
+            return false;
     }
     if (out->dirty & 0x04) {
         if (!bc_buf_read_cv3(&buf, &out->fwd_x, &out->fwd_y, &out->fwd_z))

--- a/tests/test_power_replication.c
+++ b/tests/test_power_replication.c
@@ -1,0 +1,159 @@
+#include "test_util.h"
+
+#include "openbc/ship_data.h"
+#include "openbc/ship_state.h"
+#include "openbc/ship_power.h"
+#include "openbc/game_builders.h"
+#include "openbc/buffer.h"
+#include "openbc/opcodes.h"
+
+#include <string.h>
+
+static int find_first_powered_entry(const bc_ship_class_t *cls)
+{
+    for (int i = 0; i < cls->ser_list.count; i++) {
+        if (cls->ser_list.entries[i].format == BC_SS_FORMAT_POWERED)
+            return i;
+    }
+    return -1;
+}
+
+static const bc_ship_class_t *pick_ship_with_power(const bc_game_registry_t *reg,
+                                                   int *entry_idx_out)
+{
+    for (int i = 0; i < reg->ship_count; i++) {
+        int entry = find_first_powered_entry(&reg->ships[i]);
+        if (entry >= 0) {
+            *entry_idx_out = entry;
+            return &reg->ships[i];
+        }
+    }
+    *entry_idx_out = -1;
+    return NULL;
+}
+
+static int build_single_entry_power_update(const bc_ship_state_t *ship,
+                                           const bc_ship_class_t *cls,
+                                           int entry_idx,
+                                           u8 power_byte,
+                                           u8 *out,
+                                           int out_size)
+{
+    const bc_ss_entry_t *e = &cls->ser_list.entries[entry_idx];
+    if (e->format != BC_SS_FORMAT_POWERED) return -1;
+
+    u8 fields[128];
+    bc_buffer_t fb;
+    bc_buf_init(&fb, fields, sizeof(fields));
+
+    if (!bc_buf_write_u8(&fb, (u8)entry_idx)) return -1; /* start_idx */
+    if (!bc_buf_write_u8(&fb, 0xFF)) return -1;          /* condition */
+    for (int c = 0; c < e->child_count; c++) {
+        if (!bc_buf_write_u8(&fb, 0xFF)) return -1;      /* child conditions */
+    }
+    if (!bc_buf_write_bit(&fb, true)) return -1;         /* has_power_data */
+    if (!bc_buf_write_u8(&fb, power_byte)) return -1;    /* pct/sign-bit */
+
+    return bc_build_state_update(out, out_size,
+                                 ship->object_id, 12.5f,
+                                 BC_DIRTY_SUBSYSTEM_STATES,
+                                 fields, (int)fb.pos);
+}
+
+TEST(remote_power_state_updates_percentage)
+{
+    bc_game_registry_t reg;
+    memset(&reg, 0, sizeof(reg));
+    ASSERT(bc_registry_load_dir(&reg, "data/vanilla-1.1"));
+
+    int entry_idx = -1;
+    const bc_ship_class_t *cls = pick_ship_with_power(&reg, &entry_idx);
+    ASSERT(cls != NULL);
+    ASSERT(entry_idx >= 0);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 1, 0);
+
+    u8 pkt[256];
+    int len = build_single_entry_power_update(&ship, cls, entry_idx, 55,
+                                              pkt, sizeof(pkt));
+    ASSERT(len > 0);
+
+    ship.power_pct[entry_idx] = 100;
+    ship.subsys_enabled[entry_idx] = true;
+
+    int updated = bc_ship_apply_remote_power_state(pkt, len, cls, &ship);
+    ASSERT_EQ_INT(updated, 1);
+    ASSERT_EQ_INT(ship.power_pct[entry_idx], 55);
+    ASSERT(ship.subsys_enabled[entry_idx]);
+}
+
+TEST(remote_power_state_applies_sign_bit_disable)
+{
+    bc_game_registry_t reg;
+    memset(&reg, 0, sizeof(reg));
+    ASSERT(bc_registry_load_dir(&reg, "data/vanilla-1.1"));
+
+    int entry_idx = -1;
+    const bc_ship_class_t *cls = pick_ship_with_power(&reg, &entry_idx);
+    ASSERT(cls != NULL);
+    ASSERT(entry_idx >= 0);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 1, 0);
+
+    u8 pkt[256];
+    u8 off_40 = (u8)(-(i8)40);
+    int len = build_single_entry_power_update(&ship, cls, entry_idx, off_40,
+                                              pkt, sizeof(pkt));
+    ASSERT(len > 0);
+
+    ship.power_pct[entry_idx] = 100;
+    ship.subsys_enabled[entry_idx] = true;
+
+    int updated = bc_ship_apply_remote_power_state(pkt, len, cls, &ship);
+    ASSERT_EQ_INT(updated, 1);
+    ASSERT_EQ_INT(ship.power_pct[entry_idx], 40);
+    ASSERT(!ship.subsys_enabled[entry_idx]);
+}
+
+TEST(remote_power_state_ignores_non_subsystem_updates)
+{
+    bc_game_registry_t reg;
+    memset(&reg, 0, sizeof(reg));
+    ASSERT(bc_registry_load_dir(&reg, "data/vanilla-1.1"));
+
+    int entry_idx = -1;
+    const bc_ship_class_t *cls = pick_ship_with_power(&reg, &entry_idx);
+    ASSERT(cls != NULL);
+    ASSERT(entry_idx >= 0);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 1, 0);
+
+    u8 fields[16];
+    bc_buffer_t fb;
+    bc_buf_init(&fb, fields, sizeof(fields));
+    ASSERT(bc_buf_write_cf16(&fb, 12.0f)); /* speed field */
+
+    u8 pkt[64];
+    int len = bc_build_state_update(pkt, sizeof(pkt),
+                                    ship.object_id, 3.0f,
+                                    BC_DIRTY_SPEED,
+                                    fields, (int)fb.pos);
+    ASSERT(len > 0);
+
+    ship.power_pct[entry_idx] = 77;
+    ship.subsys_enabled[entry_idx] = true;
+
+    int updated = bc_ship_apply_remote_power_state(pkt, len, cls, &ship);
+    ASSERT_EQ_INT(updated, 0);
+    ASSERT_EQ_INT(ship.power_pct[entry_idx], 77);
+    ASSERT(ship.subsys_enabled[entry_idx]);
+}
+
+TEST_MAIN_BEGIN()
+    RUN(remote_power_state_updates_percentage);
+    RUN(remote_power_state_applies_sign_bit_disable);
+    RUN(remote_power_state_ignores_non_subsystem_updates);
+TEST_MAIN_END()

--- a/tests/test_stateupdate_authority.c
+++ b/tests/test_stateupdate_authority.c
@@ -1,0 +1,138 @@
+#include "test_util.h"
+#include "test_harness.h"
+
+#include "openbc/game_builders.h"
+#include "openbc/buffer.h"
+#include "openbc/opcodes.h"
+
+#include <string.h>
+
+#define SA_PORT      29960
+#define SA_MANIFEST  "tests/fixtures/manifest.json"
+#define SA_GAME_DIR  "tests/fixtures/"
+#define SA_TIMEOUT   2000
+
+/* Minimal ObjCreateTeam with parseable ship blob header. */
+static int build_synthetic_spawn(u8 *buf, int buf_size, u8 owner_slot, u8 team_id)
+{
+    u8 blob[64];
+    memset(blob, 0, sizeof(blob));
+    blob[0] = 0x01; blob[1] = 0x00; blob[2] = 0x00; blob[3] = 0x00;
+    {
+        i32 obj_id = bc_make_ship_id(owner_slot);
+        memcpy(blob + 4, &obj_id, 4);
+    }
+    blob[8] = 1; /* species_id */
+    return bc_build_object_create_team(buf, buf_size, owner_slot, team_id,
+                                       blob, 21);
+}
+
+static int build_owner_stateupdate(i32 object_id,
+                                   f32 x, f32 y, f32 z,
+                                   f32 speed,
+                                   u8 *out, int out_size)
+{
+    u8 fields[96];
+    bc_buffer_t fb;
+    bc_buf_init(&fb, fields, sizeof(fields));
+
+    if (!bc_buf_write_f32(&fb, x)) return -1;
+    if (!bc_buf_write_f32(&fb, y)) return -1;
+    if (!bc_buf_write_f32(&fb, z)) return -1;
+    if (!bc_buf_write_bit(&fb, false)) return -1; /* no hash payload */
+    if (!bc_buf_write_cv3(&fb, 0.0f, 1.0f, 0.0f)) return -1;
+    if (!bc_buf_write_cv3(&fb, 0.0f, 0.0f, 1.0f)) return -1;
+    if (!bc_buf_write_cf16(&fb, speed)) return -1;
+
+    return bc_build_state_update(out, out_size,
+                                 object_id, 42.0f,
+                                 (u8)(BC_DIRTY_POSITION_ABS |
+                                      BC_DIRTY_ORIENT_FWD |
+                                      BC_DIRTY_ORIENT_UP |
+                                      BC_DIRTY_SPEED),
+                                 fields, (int)fb.pos);
+}
+
+TEST(stateupdate_downstream_is_server_shaped)
+{
+    bc_test_server_t srv;
+    bc_test_client_t a, b;
+    memset(&srv, 0, sizeof(srv));
+    memset(&a, 0, sizeof(a));
+    memset(&b, 0, sizeof(b));
+
+    ASSERT(bc_net_init());
+    ASSERT(test_server_start(&srv, SA_PORT, SA_MANIFEST));
+    ASSERT(test_client_connect(&a, SA_PORT, "SA_A", 0, SA_GAME_DIR));
+    ASSERT(test_client_connect(&b, SA_PORT, "SA_B", 1, SA_GAME_DIR));
+
+    test_client_drain(&a, 500);
+    test_client_drain(&b, 500);
+
+    /* Ensure both peers have ships so the 10 Hz lane broadcaster is active. */
+    {
+        u8 spawn_a[96], spawn_b[96];
+        int len_a = build_synthetic_spawn(spawn_a, sizeof(spawn_a), 0, 0);
+        int len_b = build_synthetic_spawn(spawn_b, sizeof(spawn_b), 1, 1);
+        ASSERT(len_a > 0);
+        ASSERT(len_b > 0);
+        ASSERT(test_client_send_reliable(&a, spawn_a, len_a));
+        ASSERT(test_client_send_reliable(&b, spawn_b, len_b));
+    }
+
+    Sleep(250);
+    test_client_drain(&a, 300);
+    test_client_drain(&b, 300);
+
+    /* Send an owner-style movement update from A. */
+    u8 su[128];
+    int su_len = build_owner_stateupdate(bc_make_ship_id(0),
+                                         123.0f, -77.0f, 19.0f,
+                                         8.0f,
+                                         su, sizeof(su));
+    ASSERT(su_len > 0);
+    ASSERT(test_client_send_unreliable(&a, su, su_len));
+
+    bool saw_state = false;
+    bool saw_subsystems = false;
+    bool saw_mixed_3x = false;
+    bool saw_weapon_flag = false;
+    bool saw_verbatim = false;
+
+    u32 start = GetTickCount();
+    while ((int)(GetTickCount() - start) < 1200) {
+        int msg_len = 0;
+        const u8 *msg = test_client_recv_msg(&b, &msg_len, 100);
+        if (!msg || msg_len <= 0) continue;
+        if (msg[0] != BC_OP_STATE_UPDATE) continue;
+
+        saw_state = true;
+        if (msg_len == su_len && memcmp(msg, su, (size_t)su_len) == 0) {
+            saw_verbatim = true;
+        }
+
+        if (msg_len > 9) {
+            u8 dirty = msg[9];
+            if (dirty & BC_DIRTY_SUBSYSTEM_STATES) saw_subsystems = true;
+            if ((dirty & BC_DIRTY_SUBSYSTEM_STATES) && (dirty & 0x1C))
+                saw_mixed_3x = true;
+            if (dirty & BC_DIRTY_WEAPON_STATES) saw_weapon_flag = true;
+        }
+    }
+
+    ASSERT(saw_state);
+    ASSERT(saw_subsystems);
+    ASSERT(saw_mixed_3x);
+    ASSERT(!saw_weapon_flag);
+    ASSERT(!saw_verbatim);
+
+    test_client_disconnect(&b);
+    test_client_disconnect(&a);
+    Sleep(100);
+    test_server_stop(&srv);
+    bc_net_shutdown();
+}
+
+TEST_MAIN_BEGIN()
+    RUN(stateupdate_downstream_is_server_shaped);
+TEST_MAIN_END()


### PR DESCRIPTION
## Summary
- stop verbatim relay of owner `0x1C` payloads and treat inbound StateUpdate as server input only
- generate server-shaped downstream `0x1C` at the 10 Hz lane tick (`owner: 0x20`, `remote: mixed 0x3D`)
- apply inbound engineering power intent from `0x20` subsystem blocks to server ship state before downstream broadcast

## Changes
- `src/server/server_dispatch.c`
  - absorb inbound `BC_OP_STATE_UPDATE` instead of relaying raw owner payloads
  - update server-tracked movement/orientation/speed from parsed owner input
  - apply inbound `0x20` power intent via `bc_ship_apply_remote_power_state(...)`
- `src/server/main.c`
  - add mixed downstream builder for remote observers (`0x3D` = movement + subsystem window)
  - keep owner lane on subsystem-only `0x20` and remote lanes on server-shaped mixed stream
- `src/shared/protocol/game_events.c` + `include/openbc/game_events.h`
  - parse/skip `0x01` hash bit correctly
  - parse/store `0x02` delta fields for server movement tracking
- `src/shared/game/ship_power.c` + `include/openbc/ship_power.h`
  - add `bc_ship_apply_remote_power_state(...)` to ingest inbound power percentage + sign-bit on/off intent from `0x20`
- tests
  - add `tests/test_power_replication.c` (power intent decoding + sign-bit disable regression coverage)
  - add `tests/test_stateupdate_authority.c` (integration coverage for server-shaped downstream behavior)

## Testing
- `make all PLATFORM=Windows`
- `make test PLATFORM=Windows`
  - clean validation run in a fresh worktree: `31 passed, 0 failed`

## Issue reference
Closes #186


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for replicating and applying remote ship power state updates across networked clients and server
  * State updates now include positional delta information for enhanced position tracking

* **Refactor**
  * Improved state update broadcast mechanism to differentiate between owner-controlled and observer-perspective payloads, with fallback handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->