### PR TITLE
Batch: scoring, event-relay, combat balance, net infra, ship-ser validation (closes #188-#192,#201-#203,#205)

### DIFF
--- a/docs/modding/toml-reference.md
+++ b/docs/modding/toml-reference.md
@@ -20,7 +20,14 @@ system = 1                  # Star system index (1-9)
 time_limit = -1             # Time limit in minutes (-1 = none)
 frag_limit = -1             # Kill limit (-1 = none)
 collision_damage = true     # Enable collision damage
-friendly_fire = false       # Enable team damage
+friendly_fire = false       # Enable team damage (whether FF damage applies)
+# Friendly-fire tracking (independent of friendly_fire above):
+#   "permissive" = no tracking, no warnings (default)
+#   "warning"    = track + warn at threshold, never end game (stock default)
+#   "strict"     = track + warn + end game once tolerance is exceeded
+friendly_fire_mode = "permissive"
+friendly_fire_tolerance = 1000.0       # FF damage that ends game (strict mode)
+friendly_fire_warning_points = 100.0   # FF damage that fires a one-shot warning
 difficulty = 1              # 0=Easy, 1=Normal, 2=Hard
 respawn_time = 10           # Seconds before respawn
 mode_file = ""              # Optional game mode TOML file

--- a/include/openbc/combat.h
+++ b/include/openbc/combat.h
@@ -128,6 +128,14 @@ void bc_combat_shield_tick(bc_ship_state_t *ship,
  * drops below this, the cloak fails and decloaking begins. */
 #define BC_CLOAK_ENERGY_THRESHOLD 0.5f
 
+/* Shield-delay window (seconds) for cloak transitions (Issue #192).
+ * Wire-protocol trace analysis of a stock dedicated server session shows the
+ * shield-active state change is deferred by this delay relative to the cloak
+ * transition: shields stay up ~1.0s after cloak-up begins (vulnerability
+ * window) and re-enable ~1.0s after decloak completes (grace window).
+ * This is a class-level global shared by all cloaking devices. */
+#define BC_CLOAK_SHIELD_DELAY 1.0f
+
 /* Begin cloaking. Shields functionally disabled (stop absorbing/recharging)
  * but HP preserved. Weapons disabled.
  * Returns false if ship cannot cloak (no device, dead, already cloaking/cloaked). */
@@ -197,5 +205,41 @@ void bc_repair_tick(bc_ship_state_t *ship,
 /* Auto-queue any subsystem below its disabled threshold. */
 void bc_repair_auto_queue(bc_ship_state_t *ship,
                            const bc_ship_class_t *cls);
+
+/* --- Friendly-fire tracking (Issue #203) --- */
+
+/* Friendly-fire tracking mode.
+ *  PERMISSIVE: no tracking, no warnings (legacy OpenBC behavior).
+ *  WARNING:    track + warn at warning_points threshold; never end game (stock
+ *              default — mission startup typically warns at 100 points).
+ *  STRICT:     track + warn + end game once tolerance is exceeded. */
+typedef enum {
+    BC_FF_MODE_PERMISSIVE = 0,
+    BC_FF_MODE_WARNING    = 1,
+    BC_FF_MODE_STRICT     = 2
+} bc_ff_mode_t;
+
+/* Per-server friendly-fire accumulator state. Mirrors the stock three-float
+ * model (tolerance / current / warning_points) plus the game-over toggle. */
+typedef struct {
+    bc_ff_mode_t mode;
+    f32  tolerance;              /* cumulative FF damage that crosses threshold */
+    f32  current;               /* running FF damage accumulator */
+    f32  warning_points;        /* threshold at which a warning fires */
+    bool game_over_on_threshold;/* end game when current >= tolerance */
+    bool warned;                /* one-shot latch: warning already emitted */
+} bc_friendly_fire_t;
+
+/* Outcome flags from a single FF accumulation step (bc_ff_step). */
+typedef struct {
+    bool warned;     /* warning threshold crossed on THIS step (one-shot) */
+    bool game_over;  /* tolerance exceeded AND game_over_on_threshold set */
+} bc_ff_outcome_t;
+
+/* Pure FF accumulation/decision step (no I/O, no globals).
+ * Mutates ff->current and ff->warned; returns what reactions are due so the
+ * caller can perform the wire-side emits. No-op (zero outcome) in PERMISSIVE
+ * mode or for non-positive damage. Unit-testable in isolation. */
+bc_ff_outcome_t bc_ff_step(bc_friendly_fire_t *ff, f32 damage_amount);
 
 #endif /* OPENBC_COMBAT_H */

--- a/include/openbc/combat.h
+++ b/include/openbc/combat.h
@@ -185,14 +185,34 @@ bool bc_repair_add(bc_ship_state_t *ship, u8 subsys_idx);
 /* Remove a subsystem from the repair queue. */
 void bc_repair_remove(bc_ship_state_t *ship, u8 subsys_idx);
 
+/* Repair-tick outcome kinds reported via bc_repair_tick()'s out-parameter.
+ * The simulation layer is network-agnostic; the server translates these into
+ * the matching PythonEvent (0x06) wire emissions (REPAIR_COMPLETED /
+ * REPAIR_CANNOT_BE_COMPLETED). */
+#define BC_REPAIR_EVT_COMPLETED  0  /* subsystem reached max condition */
+#define BC_REPAIR_EVT_CANNOT     1  /* subsystem destroyed (0 HP) while queued */
+
+typedef struct {
+    u8  subsys_index;  /* flat subsystem index (into ship->subsystem_hp[]) */
+    u8  kind;          /* BC_REPAIR_EVT_COMPLETED or BC_REPAIR_EVT_CANNOT */
+} bc_repair_event_t;
+
 /* Tick repair: heal up to num_repair_teams subsystems simultaneously.
  * raw_repair = max_repair_points * repair_system_health_pct * dt
  * per_sub = raw_repair / min(queue_count, num_repair_teams)
  * condition_gain = per_sub / repair_complexity
- * Destroyed subsystems (0 HP) are skipped but remain in queue. */
+ *
+ * Queue transitions are reported through the optional out_events array (caller
+ * supplies storage, capacity = out_cap). *out_count is set to the number of
+ * events written (0..out_cap). When a queued subsystem reaches max condition a
+ * BC_REPAIR_EVT_COMPLETED entry is emitted and the entry is removed; when a
+ * queued subsystem is found at 0 HP a BC_REPAIR_EVT_CANNOT entry is emitted and
+ * the entry is removed. Pass out_events=NULL / out_count=NULL to ignore. */
 void bc_repair_tick(bc_ship_state_t *ship,
                     const bc_ship_class_t *cls,
-                    f32 dt);
+                    f32 dt,
+                    bc_repair_event_t *out_events, int out_cap,
+                    int *out_count);
 
 /* Auto-queue any subsystem below its disabled threshold. */
 void bc_repair_auto_queue(bc_ship_state_t *ship,

--- a/include/openbc/config.h
+++ b/include/openbc/config.h
@@ -56,6 +56,12 @@ typedef struct {
     int  frag_limit;          /* Kill count; -1 = no limit */
     bool collision_damage;
     bool friendly_fire;
+    /* Friendly-fire tracking (Issue #203). Independent of friendly_fire, which
+     * gates whether FF damage applies at all; these control accumulation /
+     * warnings / game-over. mode: "permissive" (default), "warning", "strict". */
+    char friendly_fire_mode[16];
+    double friendly_fire_tolerance;       /* FF damage that ends game (strict) */
+    double friendly_fire_warning_points;  /* FF damage that fires a warning */
     int  difficulty;          /* 0=Easy, 1=Normal, 2=Hard */
     int  respawn_time;        /* Seconds */
     char mode_file[256];      /* Optional game-mode TOML path */

--- a/include/openbc/event_bus.h
+++ b/include/openbc/event_bus.h
@@ -44,6 +44,26 @@ typedef struct obc_event_ctx {
     bool        suppress_relay; /* One-way latch: once true, later handlers cannot clear. */
 } obc_event_ctx_t;
 
+/*
+ * Payload for the "player_connected" event (fired at transport-level peer add,
+ * before checksum exchange begins).  Cast obc_event_ctx_t.event_data to this
+ * when event_name == "player_connected".
+ *
+ * slot      : 0-based peer slot index assigned to the new peer.
+ * wire_id   : 1-based wire/network ID (slot + 1), as seen by other peers.
+ * addr_ip   : peer source IP, network byte order (0 if unknown).
+ * addr_port : peer source UDP port, network byte order (0 if unknown).
+ */
+typedef struct obc_peer_info {
+    int          slot;
+    int          wire_id;
+    unsigned int addr_ip;
+    unsigned short addr_port;
+} obc_peer_info_t;
+
+/* Canonical event name for the transport-level connect notification (#202). */
+#define OBC_EVENT_PLAYER_CONNECTED "player_connected"
+
 /* Handler function type. api is the same table received at module load. */
 typedef void (*obc_event_handler_fn)(const obc_engine_api_t *api,
                                      obc_event_ctx_t        *ctx);

--- a/include/openbc/game_builders.h
+++ b/include/openbc/game_builders.h
@@ -168,6 +168,23 @@ int bc_build_restart_game(u8 *buf, int buf_size);
 #define BC_EVENT_NEW_PLAYER          0x008000F1  /* adds player to engine player list */
 #define BC_EVENT_PLAYER_REMOVED      0x00060005  /* removes player from engine player list */
 
+/* Connect-event broadcast (mechanism #3): transport-level join/leave events
+ * the host forwards to already-connected peers so they learn about a new peer
+ * before checksum exchange.  Distinct from the per-handler game-data relay and
+ * from Python script messaging.
+ *
+ * ET_NEW_PEER_CONNECTED (0x00060007) fires when a new peer completes the
+ * transport-layer connect handshake.  The complementary
+ * BC_EVENT_PLAYER_REMOVED (0x00060005) is the disconnect side.  Both ride the
+ * DeletePlayerUI (0x17) event transport (factory BC_FACTORY_DELETE_PLAYER_UI).
+ */
+#define BC_EVENT_NEW_PEER_CONNECTED  0x00060007
+
+/* Build a connect-event broadcast message for opcode 0x17.
+ * [0x17][factory=0x866:i32][event=0x00060007:i32][src=0:i32][tgt=0:i32][wire_peer:u8]
+ * 18 bytes total.  wire_peer_id is the new peer's 1-based wire/network ID. */
+int bc_build_new_peer_connected(u8 *buf, int buf_size, u8 wire_peer_id);
+
 /* SubsystemEvent: [0x06][factory=0x101:i32][event_type:i32][source:i32][dest:i32]
  * 17 bytes total. Used for ADD_TO_REPAIR_LIST, REPAIR_COMPLETED, etc. */
 int bc_build_python_subsystem_event(u8 *buf, int buf_size,

--- a/include/openbc/game_events.h
+++ b/include/openbc/game_events.h
@@ -154,4 +154,30 @@ typedef struct {
 bool bc_parse_delete_player_anim(const u8 *payload, int len,
                                   bc_delete_player_anim_event_t *out);
 
+/* ObjectExplodingEvent -- the canonical ship-death wire signal, carried as a
+ * PythonEvent (opcode 0x06).  A dying ship's client emits this on death; the
+ * host observes it to attribute the kill and broadcast SCORE_CHANGE (0x36).
+ *
+ * Wire: [0x06][factory:i32=0x8129][event_type:i32=0x4E]
+ *       [source_obj:i32][dest_obj:i32][killer_id:i32][lifetime:f32]
+ * 25 bytes total.
+ *
+ *   dest_obj   = the dying ship's object ID
+ *   source_obj = the killer's ship object ID, or 0 for self-destruct / env
+ *   killer_id  = duplicate of source for the firing player (0 = no killer)
+ *   lifetime   = wreckage visual lifetime in seconds */
+typedef struct {
+    i32  source_object_id;   /* killer ship object ID (0 = none) */
+    i32  dest_object_id;     /* dying ship object ID */
+    i32  killer_id;          /* firing-player object ID (0 = none) */
+    f32  lifetime;           /* wreckage lifetime seconds */
+} bc_exploding_event_t;
+
+/* Parse a PythonEvent payload as an ObjectExplodingEvent.
+ * Returns true only if the opcode is 0x06 AND the factory ID identifies the
+ * exploding-event factory; returns false for any other PythonEvent so callers
+ * can cheaply test inbound 0x06 traffic for the kill signal. */
+bool bc_parse_python_exploding_event(const u8 *payload, int len,
+                                     bc_exploding_event_t *out);
+
 #endif /* OPENBC_GAME_EVENTS_H */

--- a/include/openbc/master.h
+++ b/include/openbc/master.h
@@ -45,6 +45,31 @@ int bc_master_init_defaults(bc_master_list_t *ml, u16 game_port);
 /* Add a single master server by "host:port". Returns true if DNS resolved. */
 bool bc_master_add(bc_master_list_t *ml, const char *host_port, u16 game_port);
 
+/* Maximum "host:port" entries collected from a masterserver.txt file. */
+#define BC_MASTERSERVER_TXT_MAX  BC_MAX_MASTERS
+
+/*
+ * Parse a masterserver.txt-style file (one "host:port" per line).
+ *
+ * Format rules (matches the stock runtime-override mechanism):
+ *   - One "host:port" entry per line.
+ *   - Lines whose first non-whitespace character is '#' are comments (skipped).
+ *   - Blank / whitespace-only lines are skipped.
+ *   - Leading/trailing whitespace and trailing CR (\r) are trimmed.
+ *   - Inline trailing comments after a '#' are stripped.
+ *
+ * Entries are appended to out[] (up to max_out) and the count is returned.
+ * Order is preserved: the first non-comment line is out[0], so a caller that
+ * only wants the older "first line wins" behaviour can use out[0].
+ *
+ * Returns the number of entries parsed (0 if the file is empty or all
+ * comments), or -1 if the file cannot be opened (caller should fall back to
+ * defaults). DNS resolution is NOT performed here -- this is a pure parser so
+ * it can be unit-tested without a network; resolution happens in bc_master_add.
+ */
+int bc_master_parse_txt(const char *path,
+                        char out[][128], int max_out);
+
 /* Startup probe: heartbeat all masters, wait for responses, log results.
  * If info is non-NULL, responds to GameSpy queries received during probe. */
 void bc_master_probe(bc_master_list_t *ml, bc_socket_t *sock,

--- a/include/openbc/server_state.h
+++ b/include/openbc/server_state.h
@@ -8,6 +8,7 @@
 #include "openbc/manifest.h"
 #include "openbc/master.h"
 #include "openbc/ship_data.h"
+#include "openbc/combat.h"
 #include "openbc/torpedo_tracker.h"
 #include "openbc/gamespy.h"
 
@@ -84,6 +85,26 @@ extern bool        g_accept_new_players;
 extern bool             g_game_ended;
 
 #define BC_TEAM_NONE 0xFF
+
+/* --- Friendly-fire tracking (Issue #203) ---
+ * Core types (bc_ff_mode_t, bc_friendly_fire_t, bc_ff_outcome_t) and the pure
+ * accumulation step bc_ff_step() live in <openbc/combat.h>. The declarations
+ * below are the server-side global + I/O wrappers. */
+
+extern bc_friendly_fire_t g_ff;
+
+/* Reset FF accumulator/latch to a fresh round (keeps configured thresholds). */
+void bc_ff_reset_round(void);
+
+/* Configure the FF tracker from the parsed three-mode config. Sets thresholds
+ * and game-over policy based on mode; resets the round accumulator. */
+void bc_ff_configure(bc_ff_mode_t mode, f32 tolerance, f32 warning_points);
+
+/* Record same-team (friendly-fire) damage and react per the configured mode.
+ * Wraps bc_ff_step() on g_ff and performs the side effects: fires a one-shot
+ * warning chat at warning_points and (STRICT only) triggers END_GAME once
+ * `current` exceeds tolerance. Returns true if the warning fired on this call. */
+bool bc_ff_record(f32 damage_amount);
 
 typedef struct {
     f32 shield_damage;

--- a/include/openbc/ship_state.h
+++ b/include/openbc/ship_state.h
@@ -45,6 +45,16 @@ typedef struct {
     u8         cloak_state;
     f32        cloak_timer;
 
+    /* Shield-delay window during cloak transitions (Issue #192).
+     * Stock defers the shield-active state change by ShieldDelay (1.0s) on both
+     * cloak-begin and decloak-complete, producing a 1s vulnerability window on
+     * cloak-up and a 1s grace window on decloak. Implemented as a countdown:
+     * while shield_delay_timer > 0 the shield-active state is FROZEN at
+     * shield_active_now; when it reaches 0 the pending state takes effect. */
+    f32        shield_delay_timer;     /* seconds remaining; 0 = no pending change */
+    u8         shield_delay_pending;   /* shield-active state to apply when timer expires */
+    u8         shield_active_now;      /* current (effective) shield-active state */
+
     /* Weapons */
     f32        phaser_charge[BC_MAX_PHASER_BANKS];
     f32        torpedo_cooldown[BC_MAX_TORPEDO_TUBES];

--- a/src/server/config.c
+++ b/src/server/config.c
@@ -170,10 +170,12 @@ static void process_game_section(toml_table_t *root, obc_server_cfg_t *cfg)
     }
 
     value = toml_table_double(game, "friendly_fire_tolerance");
-    if (value.ok) cfg->friendly_fire_tolerance = value.u.d;
+    if (value.ok && !isnan(value.u.d) && !isinf(value.u.d))
+        cfg->friendly_fire_tolerance = value.u.d;
 
     value = toml_table_double(game, "friendly_fire_warning_points");
-    if (value.ok) cfg->friendly_fire_warning_points = value.u.d;
+    if (value.ok && !isnan(value.u.d) && !isinf(value.u.d))
+        cfg->friendly_fire_warning_points = value.u.d;
 
     value = toml_table_int(game, "difficulty");
     if (value.ok) {

--- a/src/server/config.c
+++ b/src/server/config.c
@@ -162,6 +162,19 @@ static void process_game_section(toml_table_t *root, obc_server_cfg_t *cfg)
     value = toml_table_bool(game, "friendly_fire");
     if (value.ok) cfg->friendly_fire = value.u.b;
 
+    value = toml_table_string(game, "friendly_fire_mode");
+    if (value.ok) {
+        str_copy(cfg->friendly_fire_mode, sizeof(cfg->friendly_fire_mode),
+                 value.u.s);
+        free(value.u.s);
+    }
+
+    value = toml_table_double(game, "friendly_fire_tolerance");
+    if (value.ok) cfg->friendly_fire_tolerance = value.u.d;
+
+    value = toml_table_double(game, "friendly_fire_warning_points");
+    if (value.ok) cfg->friendly_fire_warning_points = value.u.d;
+
     value = toml_table_int(game, "difficulty");
     if (value.ok) {
         int parsed_difficulty = 0;
@@ -397,6 +410,10 @@ void obc_config_defaults(obc_server_cfg_t *cfg)
     cfg->frag_limit       = -1;
     cfg->collision_damage = true;
     cfg->friendly_fire    = false;
+    str_copy(cfg->friendly_fire_mode, sizeof(cfg->friendly_fire_mode),
+             "permissive");
+    cfg->friendly_fire_tolerance      = 1000.0;
+    cfg->friendly_fire_warning_points = 100.0;  /* stock default */
     cfg->difficulty       = 1;
     cfg->respawn_time     = 10;
 

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -883,8 +883,42 @@ int main(int argc, char **argv)
                     bc_cloak_tick(&p->ship, /* cloak_efficiency */ clk_eff,
                                  /* dt */ dt);
 
-                    /* Repair */
-                    bc_repair_tick(&p->ship, cls, dt);
+                    /* Repair.
+                     * Queue transitions (subsystem fully repaired, or destroyed
+                     * while queued) must be announced to clients so their
+                     * Engineering panel state stays in sync. Stock emits these
+                     * as PythonEvent (0x06) to all peers, reliably:
+                     *   - REPAIR_COMPLETED (0x00800074): factory 0x0101 TGEvent
+                     *   - REPAIR_CANNOT_BE_COMPLETED (0x00800075): factory 0x010C
+                     *     TGObjPtrEvent (carries the subsystem obj_ptr).
+                     * Host-only: only the simulating server emits these. */
+                    {
+                        bc_repair_event_t rq_evts[BC_MAX_SUBSYSTEMS];
+                        int rq_count = 0;
+                        bc_repair_tick(&p->ship, cls, dt,
+                                       rq_evts, BC_MAX_SUBSYSTEMS, &rq_count);
+                        for (int e = 0; e < rq_count; e++) {
+                            int ss_idx = rq_evts[e].subsys_index;
+                            if (ss_idx < 0 || ss_idx >= BC_MAX_SUBSYSTEMS) continue;
+                            i32 ss_obj = p->ship.subsys_obj_id[ss_idx];
+                            i32 repair_obj = p->ship.repair_subsys_obj_id;
+                            if (rq_evts[e].kind == BC_REPAIR_EVT_COMPLETED) {
+                                u8 evt[17];
+                                int len = bc_build_python_subsystem_event(
+                                    evt, sizeof(evt),
+                                    BC_EVENT_REPAIR_COMPLETED,
+                                    repair_obj, ss_obj);
+                                if (len > 0) bc_send_to_all(evt, len, true);
+                            } else { /* BC_REPAIR_EVT_CANNOT */
+                                u8 evt[21];
+                                int len = bc_build_python_obj_ptr_event(
+                                    evt, sizeof(evt),
+                                    BC_EVENT_REPAIR_CANNOT,
+                                    repair_obj, ss_obj, ss_obj);
+                                if (len > 0) bc_send_to_all(evt, len, true);
+                            }
+                        }
+                    }
                     bc_repair_auto_queue(&p->ship, cls);
 
                     /* Tractor beam physics: drag target if engaged */

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -1017,7 +1017,7 @@ int main(int argc, char **argv)
                     /* Build remote version (with power data) using same
                      * start_idx so both cover the same entries. */
                     u8 hbuf_rmt[128];
-                    u8 rmt_next;
+                    u8 rmt_next = p->subsys_rr_idx;
                     int hlen_rmt = bc_ship_build_health_update(
                         &p->ship, cls, g_game_time,
                         p->subsys_rr_idx, &rmt_next, false,

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -345,6 +345,19 @@ int main(int argc, char **argv)
         }
     }
 
+    /* Issue #203: configure friendly-fire tracking from config (CLI flags
+     * --friendly-fire/--no-friendly-fire only gate whether FF damage applies;
+     * the tracking mode comes from [game].friendly_fire_mode). */
+    {
+        bc_ff_mode_t ff_mode = BC_FF_MODE_PERMISSIVE;
+        const char *m = g_server_cfg.friendly_fire_mode;
+        if (strcmp(m, "warning") == 0)      ff_mode = BC_FF_MODE_WARNING;
+        else if (strcmp(m, "strict") == 0)  ff_mode = BC_FF_MODE_STRICT;
+        bc_ff_configure(ff_mode,
+                        (f32)g_server_cfg.friendly_fire_tolerance,
+                        (f32)g_server_cfg.friendly_fire_warning_points);
+    }
+
     /* Apply parsed settings to globals */
     g_map_name = map;
     g_max_players = max_players;

--- a/src/server/main.c
+++ b/src/server/main.c
@@ -649,14 +649,33 @@ int main(int argc, char **argv)
              "Dedicated Server");
     g_info.player_count = 1;
 
-    /* Master server registration */
+    /* Master server registration.
+     * Precedence (highest first):
+     *   1. --master CLI flag / server.toml masters (collected in user_masters)
+     *   2. masterserver.txt in the working directory (runtime override)
+     *   3. Baked-in default master list
+     */
     memset(&g_masters, 0, sizeof(g_masters));
     if (!no_master) {
         if (user_master_count > 0) {
             for (int i = 0; i < user_master_count; i++)
                 bc_master_add(&g_masters, user_masters[i], port);
         } else {
-            bc_master_init_defaults(&g_masters, port);
+            /* No CLI/TOML masters -- check for a masterserver.txt override. */
+            static char txt_masters[BC_MASTERSERVER_TXT_MAX][128];
+            int txt_count = bc_master_parse_txt("masterserver.txt",
+                                                txt_masters,
+                                                BC_MASTERSERVER_TXT_MAX);
+            if (txt_count > 0) {
+                LOG_INFO("master", "masterserver.txt found: %d entr%s",
+                         txt_count, txt_count == 1 ? "y" : "ies");
+                memset(&g_masters, 0, sizeof(g_masters));
+                g_masters.game_port = port;
+                for (int i = 0; i < txt_count; i++)
+                    bc_master_add(&g_masters, txt_masters[i], port);
+            } else {
+                bc_master_init_defaults(&g_masters, port);
+            }
         }
         if (g_masters.count > 0)
             bc_master_probe(&g_masters, &g_socket, &g_info);

--- a/src/server/network/master.c
+++ b/src/server/network/master.c
@@ -120,6 +120,48 @@ bool bc_master_add(bc_master_list_t *ml, const char *host_port, u16 game_port)
     return true;
 }
 
+int bc_master_parse_txt(const char *path,
+                        char out[][128], int max_out)
+{
+    if (!path || !out || max_out <= 0) return -1;
+
+    FILE *f = fopen(path, "r");
+    if (!f) return -1;
+
+    int count = 0;
+    char line[256];
+    while (count < max_out && fgets(line, sizeof(line), f)) {
+        /* Strip trailing newline / carriage return. */
+        size_t len = strlen(line);
+        while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
+            line[--len] = '\0';
+
+        /* Skip leading whitespace. */
+        char *p = line;
+        while (*p == ' ' || *p == '\t') p++;
+
+        /* Skip comments and blank lines. */
+        if (*p == '#' || *p == '\0') continue;
+
+        /* Strip an inline trailing comment ("host:port  # note"). */
+        char *hash = strchr(p, '#');
+        if (hash) *hash = '\0';
+
+        /* Trim trailing whitespace from the entry. */
+        size_t plen = strlen(p);
+        while (plen > 0 && (p[plen - 1] == ' ' || p[plen - 1] == '\t'))
+            p[--plen] = '\0';
+
+        if (plen == 0) continue;  /* whitespace-only after comment strip */
+
+        snprintf(out[count], 128, "%s", p);
+        count++;
+    }
+
+    fclose(f);
+    return count;
+}
+
 int bc_master_init_defaults(bc_master_list_t *ml, u16 game_port)
 {
     memset(ml, 0, sizeof(*ml));

--- a/src/server/network/master.c
+++ b/src/server/network/master.c
@@ -131,8 +131,18 @@ int bc_master_parse_txt(const char *path,
     int count = 0;
     char line[256];
     while (count < max_out && fgets(line, sizeof(line), f)) {
-        /* Strip trailing newline / carriage return. */
         size_t len = strlen(line);
+
+        /* If the line was longer than the buffer, fgets stopped mid-line with
+         * no newline. Drain the remainder of the over-long line and skip it
+         * entirely, rather than parse a truncated head plus a bogus tail entry. */
+        if (len > 0 && line[len - 1] != '\n' && !feof(f)) {
+            int ch;
+            while ((ch = fgetc(f)) != '\n' && ch != EOF) { }
+            continue;
+        }
+
+        /* Strip trailing newline / carriage return. */
         while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r'))
             line[--len] = '\0';
 

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -1017,9 +1017,70 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
     }
 
     /* --- Python events (reliable) --- */
-    case BC_OP_PYTHON_EVENT:
+    case BC_OP_PYTHON_EVENT: {
+        /* ObjectExplodingEvent (factory 0x8129) is the canonical ship-death
+         * signal.  The dying ship's client emits it on death; the host must
+         * observe it to attribute the kill and broadcast SCORE_CHANGE (0x36).
+         *
+         * Wire-protocol trace analysis of a stock dedicated server session
+         * shows weapon kills are frequently delivered to the victim via
+         * per-tick health replication (StateUpdate) rather than a discrete
+         * server-applied damage hit -- so the server-side combat paths
+         * (beam/torpedo/collision/self-destruct) do not always observe the
+         * killing blow.  Treat the inbound exploding-event as a fallback kill
+         * detector: score it only when the server has not already retired the
+         * victim's ship (ship still alive).  When the server already processed
+         * the death, the victim's ship is no longer alive and we skip, so the
+         * two paths never double-count. */
+        bc_exploding_event_t expl_ev;
+        if (!g_game_ended &&
+            bc_parse_python_exploding_event(payload, payload_len, &expl_ev)) {
+            int victim_slot = -1;
+            int vgs = bc_object_id_to_slot(expl_ev.dest_object_id);
+            if (vgs >= 0 && vgs + 1 < BC_MAX_PLAYERS) victim_slot = vgs + 1;
+
+            if (victim_slot > 0 &&
+                g_peers.peers[victim_slot].has_ship &&
+                g_peers.peers[victim_slot].ship.alive) {
+                /* Resolve the killer.  source_object_id is the killer ship's
+                 * object ID; killer_id duplicates it.  0 => self-destruct /
+                 * environmental / AI (no kill credit). */
+                i32 killer_obj = expl_ev.source_object_id != 0
+                               ? expl_ev.source_object_id
+                               : expl_ev.killer_id;
+                bool self_destruct = (killer_obj == 0);
+                int killer_slot = -1;
+                if (!self_destruct) {
+                    int kgs = bc_object_id_to_slot(killer_obj);
+                    if (kgs >= 0 && kgs + 1 < BC_MAX_PLAYERS)
+                        killer_slot = kgs + 1;
+                    /* A killer slot that is not an active player ship yields
+                     * no kill credit (e.g. AI / departed peer). */
+                    if (killer_slot > 0 &&
+                        g_peers.peers[killer_slot].state < PEER_LOBBY)
+                        killer_slot = -1;
+                }
+
+                /* Retire the victim ship before scoring so the server-side
+                 * combat path cannot re-score the same death. */
+                g_peers.peers[victim_slot].ship.alive = false;
+                g_peers.peers[victim_slot].has_ship = false;
+                g_peers.peers[victim_slot].respawn_timer = 0.0f;
+                g_peers.peers[victim_slot].respawn_class = -1;
+
+                LOG_INFO("combat",
+                         "client-reported kill: victim=%s killer=%s%s",
+                         peer_name(victim_slot),
+                         self_destruct ? "(none)"
+                                       : object_owner_name(killer_obj),
+                         self_destruct ? " [self-destruct]" : "");
+
+                process_ship_kill(killer_slot, victim_slot, self_destruct);
+            }
+        }
         bc_relay_to_others(peer_slot, payload, payload_len, true);
         break;
+    }
 
     case BC_OP_PYTHON_EVENT2:
         /* C->S only; server absorbs locally, does NOT relay (0 S->C in stock trace) */

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -697,21 +697,14 @@ static void apply_beam_damage(int shooter_slot, int target_slot)
             if (elen > 0) bc_send_to_all(expl, elen, true);
         }
 
-        /* Send Explosion (0x29) -- visual effect for the kill.
-         * Stock BC does NOT send DestroyObject (0x14) for ship deaths;
-         * the old ship is implicitly replaced when the respawn ObjCreateTeam
-         * arrives. Verified: 0 DestroyObject messages across 59 ship deaths
-         * in a 33.5-minute combat session. */
-        {
-            u8 boom[16];
-            int blen = bc_build_explosion(boom, sizeof(boom),
-                                           target->ship.object_id,
-                                           target->ship.pos.x,
-                                           target->ship.pos.y,
-                                           target->ship.pos.z,
-                                           damage, 300.0f);
-            if (blen > 0) bc_send_to_all(boom, blen, true);
-        }
+        /* No server-originated Explosion (0x29) for the kill. Wire-protocol
+         * trace analysis of a stock dedicated server session shows the host
+         * emits 0x29 ONLY as a catch-up to late observers (RequestObj /
+         * NewPlayerInGame), never from per-tick combat. The death visual is
+         * carried by the OBJECT_EXPLODING PythonEvent (0x06) above; per-tick
+         * 0x29 here duplicated that visual on bystander clients. Stock BC also
+         * does NOT send DestroyObject (0x14) for ship deaths -- the old ship is
+         * implicitly replaced when the respawn ObjCreateTeam arrives. */
 
         process_ship_kill(shooter_slot, target_slot, false);
 
@@ -799,18 +792,10 @@ void bc_torpedo_hit_callback(int shooter_slot, i32 target_id,
             if (elen > 0) bc_send_to_all(expl, elen, true);
         }
 
-        /* Send Explosion (0x29) -- visual effect for the kill.
-         * Stock BC does NOT send DestroyObject (0x14) for ship deaths. */
-        {
-            u8 boom[16];
-            int blen = bc_build_explosion(boom, sizeof(boom),
-                                           target->ship.object_id,
-                                           impact_pos.x,
-                                           impact_pos.y,
-                                           impact_pos.z,
-                                           damage, damage_radius > 0.0f ? damage_radius : 300.0f);
-            if (blen > 0) bc_send_to_all(boom, blen, true);
-        }
+        /* No server-originated Explosion (0x29) for the kill -- see the beam
+         * kill path for the rationale. The OBJECT_EXPLODING PythonEvent (0x06)
+         * above is the sole kill-visual emission; stock emits 0x29 only as a
+         * catch-up to late observers, never from per-tick combat. */
 
         process_ship_kill(shooter_slot, target_slot, false);
 
@@ -1018,7 +1003,18 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
 
     /* --- Python events (reliable) --- */
     case BC_OP_PYTHON_EVENT:
-        bc_relay_to_others(peer_slot, payload, payload_len, true);
+        /* Do NOT relay inbound 0x06 verbatim. Wire-protocol trace analysis of a
+         * stock dedicated server session shows 0x06 PythonEvent is
+         * server-ORIGINATED on the wire (zero client->server occurrences); the
+         * host's receive handler consumes it locally without re-broadcasting.
+         * The four events that must reach bystander clients are emitted from the
+         * server's own simulation, not relayed from client input:
+         *   - ADD_TO_REPAIR_LIST       (generate_damage_events / death burst)
+         *   - OBJECT_EXPLODING         (server death pipeline)
+         *   - REPAIR_COMPLETED         (repair tick, main loop)
+         *   - REPAIR_CANNOT_BE_COMPLETED (repair tick, main loop)
+         * Relaying inbound 0x06 verbatim produced duplicate events on bystander
+         * clients (Engineering / repair-queue UI desync). Absorb locally. */
         break;
 
     case BC_OP_PYTHON_EVENT2:

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -1078,7 +1078,11 @@ static void handle_game_message(int peer_slot, const bc_transport_msg_t *msg)
             int vgs = bc_object_id_to_slot(expl_ev.dest_object_id);
             if (vgs >= 0 && vgs + 1 < BC_MAX_PLAYERS) victim_slot = vgs + 1;
 
-            if (victim_slot > 0 &&
+            /* Anti-spoof: a client may only report the death of ITS OWN ship.
+             * The victim's object id must map back to the sending peer. Without
+             * this, any peer could send a 0x06 ObjectExplodingEvent naming an
+             * arbitrary victim and instantly kill them / manufacture scoring. */
+            if (victim_slot > 0 && victim_slot == peer_slot &&
                 g_peers.peers[victim_slot].has_ship &&
                 g_peers.peers[victim_slot].ship.alive) {
                 /* Resolve the killer.  source_object_id is the killer ship's

--- a/src/server/server_dispatch.c
+++ b/src/server/server_dispatch.c
@@ -426,6 +426,9 @@ static void record_damage_ledger(int attacker_slot, int target_slot,
     hull_damage *= mod;
 
     if (g_team_mode && same_team_slots(attacker_slot, target_slot)) {
+        /* Issue #203: track cumulative friendly-fire (pre-negation magnitude)
+         * and emit warnings / end-game per the configured FF mode. */
+        bc_ff_record(shield_damage + hull_damage);
         shield_damage = -shield_damage;
         hull_damage = -hull_damage;
     }
@@ -443,6 +446,49 @@ static void end_game_locked(i32 reason, const char *why)
     g_game_ended = true;
     g_accept_new_players = false;
     LOG_INFO("game", "EndGame: reason=%d (%s)", (int)reason, why ? why : "?");
+}
+
+/* --- Friendly-fire tracking (Issue #203) --- */
+
+void bc_ff_reset_round(void)
+{
+    g_ff.current = 0.0f;
+    g_ff.warned = false;
+}
+
+void bc_ff_configure(bc_ff_mode_t mode, f32 tolerance, f32 warning_points)
+{
+    g_ff.mode = mode;
+    g_ff.tolerance = tolerance;
+    g_ff.warning_points = warning_points;
+    /* Stock default: warnings only, never end game. STRICT mode opts in to
+     * ending the game once tolerance is exceeded. */
+    g_ff.game_over_on_threshold = (mode == BC_FF_MODE_STRICT);
+    bc_ff_reset_round();
+}
+
+bool bc_ff_record(f32 damage_amount)
+{
+    if (g_game_ended) return false;
+
+    /* Pure accumulation/decision in combat.c; emits are performed here. */
+    bc_ff_outcome_t out = bc_ff_step(&g_ff, damage_amount);
+
+    if (out.warned) {
+        u8 chat[160];
+        int clen = bc_build_chat(
+            chat, sizeof(chat), 0 /* dedi slot */, false,
+            "WARNING: friendly-fire threshold reached. Cease fire on teammates.");
+        if (clen > 0) bc_send_to_all(chat, clen, true);
+        LOG_INFO("ff", "friendly-fire warning at %.1f (threshold %.1f)",
+                 (double)g_ff.current, (double)g_ff.warning_points);
+    }
+
+    if (out.game_over) {
+        end_game_locked(BC_END_REASON_OVER, "friendly-fire tolerance exceeded");
+    }
+
+    return out.warned;
 }
 
 static void broadcast_team_scores(void)
@@ -592,6 +638,7 @@ static void reset_round_for_restart(void)
     memset(g_team_kills, 0, sizeof(g_team_kills));
     memset(g_damage_ledger, 0, sizeof(g_damage_ledger));
     memset(g_reconnect_scores, 0, sizeof(g_reconnect_scores));
+    bc_ff_reset_round();  /* Issue #203: clear FF accumulator on round restart */
     for (int i = 0; i < BC_MAX_PLAYERS; i++) g_player_teams[i] = BC_TEAM_NONE;
 
     for (int i = 1; i < BC_MAX_PLAYERS; i++) {

--- a/src/server/server_handshake.c
+++ b/src/server/server_handshake.c
@@ -11,6 +11,7 @@
 #include "openbc/game_builders.h"
 #include "openbc/player_ids.h"
 #include "openbc/ship_state.h"
+#include "openbc/event_bus.h"
 #include "openbc/log.h"
 
 #include <stdio.h>
@@ -504,6 +505,38 @@ void bc_handle_connect(const bc_addr_t *from, int len)
         memset(rec, 0, sizeof(*rec));
         snprintf(rec->name, sizeof(rec->name), "slot %d", slot);
         rec->connect_time = bc_ms_now();
+    }
+
+    /* Connect-event broadcast (#202 / routing mechanism #3).
+     *
+     * The transport-layer connect handshake is now complete and the peer slot
+     * is fully populated.  Stock fires ET_NEW_PEER_CONNECTED on the host's
+     * event manager at this moment -- BEFORE the checksum exchange begins --
+     * and forwards the connect event to already-connected peers so their
+     * peer-tracking / chat / scoreboard pre-init state updates immediately.
+     *
+     * Timing is load-bearing: this MUST happen before the checksum request
+     * below transitions the peer into PEER_CHECKSUMMING.
+     *
+     * Step 1: notify server-side subscribers (gamemode / scoring modules). */
+    {
+        obc_peer_info_t pi;
+        pi.slot      = slot;
+        pi.wire_id   = slot + 1;
+        pi.addr_ip   = from->ip;
+        pi.addr_port = from->port;
+        obc_event_fire(NULL, OBC_EVENT_PLAYER_CONNECTED, slot, &pi);
+    }
+
+    /* Step 2: broadcast the connect event to existing already-connected peers.
+     * The joining peer has no game object yet, so the event carries only its
+     * wire ID.  Sent reliably so no existing peer misses the join. */
+    {
+        u8 cpkt[20];
+        int clen = bc_build_new_peer_connected(cpkt, sizeof(cpkt),
+                                               (u8)(slot + 1));
+        if (clen > 0)
+            bc_relay_to_others(slot, cpkt, clen, true);
     }
 
     /* Send Connect response + first ChecksumReq batched in one packet.

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -61,6 +61,18 @@ bool        g_accept_new_players = true;
 /* Win condition */
 bool g_game_ended = false;
 
+/* Friendly-fire tracking (Issue #203). Defaults to PERMISSIVE (no tracking).
+ * Stock default is WARNING with warning_points=100. Configured at startup via
+ * bc_ff_configure() from server.toml / CLI. */
+bc_friendly_fire_t g_ff = {
+    BC_FF_MODE_PERMISSIVE,  /* mode */
+    1000.0f,                /* tolerance */
+    0.0f,                   /* current */
+    100.0f,                 /* warning_points (stock default) */
+    false,                  /* game_over_on_threshold */
+    false                   /* warned */
+};
+
 i32 g_player_scores[BC_MAX_PLAYERS];
 i32 g_player_kills[BC_MAX_PLAYERS];
 i32 g_player_deaths[BC_MAX_PLAYERS];

--- a/src/shared/game/combat.c
+++ b/src/shared/game/combat.c
@@ -805,10 +805,25 @@ void bc_repair_remove(bc_ship_state_t *ship, u8 subsys_idx)
  * per_sub = raw_repair / active
  * condition_gain = per_sub / repair_complexity
  * Multiple subsystems repaired simultaneously; destroyed (0 HP) skipped. */
+/* Append a repair-queue transition to the caller's output array (if any). */
+static void push_repair_event(bc_repair_event_t *out_events, int out_cap,
+                              int *out_count, u8 ss_idx, u8 kind)
+{
+    if (!out_events || !out_count) return;
+    if (*out_count >= out_cap) return;
+    out_events[*out_count].subsys_index = ss_idx;
+    out_events[*out_count].kind = kind;
+    (*out_count)++;
+}
+
 void bc_repair_tick(bc_ship_state_t *ship,
                     const bc_ship_class_t *cls,
-                    f32 dt)
+                    f32 dt,
+                    bc_repair_event_t *out_events, int out_cap,
+                    int *out_count)
 {
+    if (out_count) *out_count = 0;
+
     if (!ship->alive || dt <= 0.0f) return;
     if (ship->repair_count == 0) return;
     if (cls->max_repair_points <= 0.0f || cls->num_repair_teams <= 0) return;
@@ -835,13 +850,22 @@ void bc_repair_tick(bc_ship_state_t *ship,
     f32 per_sub = raw_repair / (f32)active;
 
     /* Process the first 'active' queue entries */
-    int repaired = 0;
+    int dequeued = 0;
     for (int q = 0; q < active && q < ship->repair_count; q++) {
         u8 ss_idx = ship->repair_queue[q];
         if (ss_idx >= (u8)cls->subsystem_count) continue;
 
-        /* Skip destroyed subsystems (0 HP) but keep in queue */
-        if (ship->subsystem_hp[ss_idx] <= 0.0f) continue;
+        /* Destroyed-while-queued: a subsystem can drop to 0 HP after it was
+         * queued (taking further damage while awaiting repair). Stock emits
+         * REPAIR_CANNOT_BE_COMPLETED and drops the entry -- it cannot be
+         * repaired from destroyed. Previously this was a silent skip. */
+        if (ship->subsystem_hp[ss_idx] <= 0.0f) {
+            push_repair_event(out_events, out_cap, out_count,
+                              ss_idx, BC_REPAIR_EVT_CANNOT);
+            ship->repair_queue[q] = 0xFF; /* mark for removal */
+            dequeued++;
+            continue;
+        }
 
         f32 complexity = cls->subsystems[ss_idx].repair_complexity;
         if (complexity <= 0.0f) complexity = 1.0f;
@@ -851,14 +875,16 @@ void bc_repair_tick(bc_ship_state_t *ship,
         ship->subsystem_hp[ss_idx] += gain;
         if (ship->subsystem_hp[ss_idx] >= max_hp) {
             ship->subsystem_hp[ss_idx] = max_hp;
+            push_repair_event(out_events, out_cap, out_count,
+                              ss_idx, BC_REPAIR_EVT_COMPLETED);
             /* Mark for removal (defer to avoid modifying while iterating) */
             ship->repair_queue[q] = 0xFF; /* sentinel */
-            repaired++;
+            dequeued++;
         }
     }
 
-    /* Remove fully repaired entries (marked 0xFF) */
-    if (repaired > 0) {
+    /* Remove completed / abandoned entries (marked 0xFF) */
+    if (dequeued > 0) {
         int w = 0;
         for (int r = 0; r < ship->repair_count; r++) {
             if (ship->repair_queue[r] != 0xFF) {

--- a/src/shared/game/combat.c
+++ b/src/shared/game/combat.c
@@ -419,7 +419,11 @@ void bc_combat_shield_tick(bc_ship_state_t *ship,
                            f32 power_level, f32 dt)
 {
     if (!ship->alive || dt <= 0.0f) return;
-    if (ship->cloak_state != BC_CLOAK_DECLOAKED) return;
+    /* Issue #192: gate recharge on the deferred shield-active state rather than
+     * raw cloak_state. No recharge during the pending-disable window (cloak-up);
+     * recharge resumes only after the pending-enable timer fires (post-decloak
+     * grace ends). */
+    if (!bc_cloak_shields_active(ship)) return;
 
     /* Special recovery path: if shield subsystem is destroyed/disabled,
      * recharge surviving facings using backup battery directly. */
@@ -577,9 +581,14 @@ bool bc_cloak_start(bc_ship_state_t *ship, const bc_ship_class_t *cls)
     ship->cloak_state = BC_CLOAK_CLOAKING;
     ship->cloak_timer = BC_CLOAK_TRANSITION_TIME;
 
-    /* Shield HP preserved — shields are functionally disabled via
-     * bc_cloak_shields_active() returning false, which causes
-     * apply_damage to skip absorption and shield_tick to skip recharge. */
+    /* Issue #192: defer the shield-disable by ShieldDelay (1.0s). Shields stay
+     * active for the first ~1.0s of cloak-up (vulnerability window). The
+     * effective shield-active state stays frozen at shield_active_now until the
+     * timer expires; the pending state (off) then takes effect.
+     * Shield HP is preserved — shields are only functionally disabled, never
+     * zeroed (bc_cloak_shields_active() drives apply_damage/shield_tick). */
+    ship->shield_delay_timer = BC_CLOAK_SHIELD_DELAY;
+    ship->shield_delay_pending = 0;  /* shields go OFF after the delay */
 
     return true;
 }
@@ -606,6 +615,12 @@ void bc_cloak_tick(bc_ship_state_t *ship, f32 cloak_efficiency, f32 dt)
         cloak_efficiency = 1.0f;
     }
 
+    /* Issue #192: snapshot whether the deferred shield-state timer was already
+     * running BEFORE this tick. A timer (re)armed by a transition below must NOT
+     * be counted down by the same dt that produced the transition — otherwise a
+     * single oversized dt could skip the entire ShieldDelay window. */
+    bool shield_timer_was_running = (ship->shield_delay_timer > 0.0f);
+
     switch (ship->cloak_state) {
     case BC_CLOAK_CLOAKING:
         ship->cloak_timer -= dt;
@@ -631,10 +646,27 @@ void bc_cloak_tick(bc_ship_state_t *ship, f32 cloak_efficiency, f32 dt)
                 if (ship->shield_hp[i] <= 0.0f)
                     ship->shield_hp[i] = 1.0f;
             }
+            /* Issue #192: defer the shield re-enable by ShieldDelay (1.0s).
+             * The ship is now fully visible but shields stay down for the first
+             * ~1.0s of visibility (grace window). */
+            ship->shield_delay_timer = BC_CLOAK_SHIELD_DELAY;
+            ship->shield_delay_pending = 1;  /* shields go ON after the delay */
         }
         break;
     default:
         break;
+    }
+
+    /* Issue #192: advance the deferred shield-state timer. While it is running
+     * the effective shield-active state stays frozen at shield_active_now;
+     * when it expires the pending state takes effect. Only advance a timer that
+     * was already running before this tick (see shield_timer_was_running). */
+    if (shield_timer_was_running && ship->shield_delay_timer > 0.0f) {
+        ship->shield_delay_timer -= dt;
+        if (ship->shield_delay_timer <= 0.0f) {
+            ship->shield_delay_timer = 0.0f;
+            ship->shield_active_now = ship->shield_delay_pending;
+        }
     }
 }
 
@@ -645,7 +677,14 @@ bool bc_cloak_can_fire(const bc_ship_state_t *ship)
 
 bool bc_cloak_shields_active(const bc_ship_state_t *ship)
 {
-    return ship->cloak_state == BC_CLOAK_DECLOAKED;
+    /* Issue #192: the shield-active state is driven by the deferred
+     * ShieldDelay timer, NOT directly by cloak_state. During the 1.0s window
+     * after a cloak transition the effective state is frozen at
+     * shield_active_now (the OLD state): shields stay up for the first ~1.0s of
+     * cloak-up (vulnerability window) and stay down for the first ~1.0s after
+     * decloak completes (grace window). bc_cloak_tick() flips shield_active_now
+     * to shield_delay_pending once the timer expires. */
+    return ship->shield_active_now != 0;
 }
 
 /* --- Tractor beams --- */
@@ -881,4 +920,35 @@ void bc_repair_auto_queue(bc_ship_state_t *ship,
             bc_repair_add(ship, (u8)i);
         }
     }
+}
+
+/* --- Friendly-fire tracking (Issue #203) ---
+ * Pure accumulation/decision step. Wire-protocol trace analysis of a stock
+ * dedicated server session shows the server maintains a cumulative friendly-
+ * fire damage accumulator with a warning threshold (typically 100 points) and
+ * an optional tolerance ceiling that ends the game (strict variants). This
+ * mirrors that three-value model with no I/O so it can be tested in isolation. */
+bc_ff_outcome_t bc_ff_step(bc_friendly_fire_t *ff, f32 damage_amount)
+{
+    bc_ff_outcome_t out = { false, false };
+    if (!ff) return out;
+    if (ff->mode == BC_FF_MODE_PERMISSIVE) return out;
+    if (!(damage_amount > 0.0f)) return out;  /* also rejects NaN */
+
+    ff->current += damage_amount;
+
+    /* One-shot warning when the accumulator first crosses warning_points. */
+    if (!ff->warned && ff->warning_points > 0.0f &&
+        ff->current >= ff->warning_points) {
+        ff->warned = true;
+        out.warned = true;
+    }
+
+    /* Tolerance ceiling ends the game only when the policy opts in. */
+    if (ff->game_over_on_threshold && ff->tolerance > 0.0f &&
+        ff->current >= ff->tolerance) {
+        out.game_over = true;
+    }
+
+    return out;
 }

--- a/src/shared/game/combat.c
+++ b/src/shared/game/combat.c
@@ -419,10 +419,13 @@ void bc_combat_shield_tick(bc_ship_state_t *ship,
                            f32 power_level, f32 dt)
 {
     if (!ship->alive || dt <= 0.0f) return;
-    /* Issue #192: gate recharge on the deferred shield-active state rather than
-     * raw cloak_state. No recharge during the pending-disable window (cloak-up);
-     * recharge resumes only after the pending-enable timer fires (post-decloak
-     * grace ends). */
+    /* Issue #192: no shield recharge while cloaking/cloaked/decloaking. The
+     * cloak-up vulnerability window keeps shields UP for absorption (via
+     * bc_cloak_shields_active() in apply_damage) but they must NOT recharge
+     * once cloak is engaged. Recharge resumes only when the ship is fully
+     * decloaked AND the post-decloak grace timer has expired (shield_active_now
+     * back to true). */
+    if (ship->cloak_state != BC_CLOAK_DECLOAKED) return;
     if (!bc_cloak_shields_active(ship)) return;
 
     /* Special recovery path: if shield subsystem is destroyed/disabled,

--- a/src/shared/game/ship_state.c
+++ b/src/shared/game/ship_state.c
@@ -20,6 +20,12 @@ void bc_ship_init(bc_ship_state_t *ship,
     ship->tractor_target_id = -1;
     ship->tractor_drag = 1.0f;
 
+    /* Spawn decloaked with shields active. shield_delay_timer = 0 (no pending
+     * change), so bc_cloak_shields_active() returns shield_active_now. */
+    ship->shield_active_now = 1;
+    ship->shield_delay_pending = 1;
+    ship->shield_delay_timer = 0.0f;
+
     /* Full HP */
     ship->hull_hp = cls->hull_hp;
     for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++) {

--- a/src/shared/protocol/game_builders.c
+++ b/src/shared/protocol/game_builders.c
@@ -379,3 +379,27 @@ int bc_build_event_forward(u8 *buf, int buf_size,
 
     return total;
 }
+
+int bc_build_new_peer_connected(u8 *buf, int buf_size, u8 wire_peer_id)
+{
+    /* Connect-event broadcast (mechanism #3): rides the DeletePlayerUI (0x17)
+     * event transport carrying ET_NEW_PEER_CONNECTED (0x00060007).
+     * Wire format (18 bytes):
+     *   [0x17]                 opcode
+     *   [factory=0x866:i32]    base event factory class ID (LE)
+     *   [event=0x00060007:i32] ET_NEW_PEER_CONNECTED (LE)
+     *   [src=0:i32]            no source object at transport connect time
+     *   [tgt=0:i32]            no target object at transport connect time
+     *   [wire_peer_id:u8]      new peer's 1-based wire/network ID */
+    bc_buffer_t b;
+    bc_buf_init(&b, buf, (size_t)buf_size);
+
+    if (!bc_buf_write_u8(&b, BC_OP_DELETE_PLAYER_UI)) return -1;
+    if (!bc_buf_write_i32(&b, (i32)BC_FACTORY_DELETE_PLAYER_UI)) return -1;
+    if (!bc_buf_write_i32(&b, (i32)BC_EVENT_NEW_PEER_CONNECTED)) return -1;
+    if (!bc_buf_write_i32(&b, 0)) return -1;
+    if (!bc_buf_write_i32(&b, 0)) return -1;
+    if (!bc_buf_write_u8(&b, wire_peer_id)) return -1;
+
+    return (int)b.pos;
+}

--- a/src/shared/protocol/game_events.c
+++ b/src/shared/protocol/game_events.c
@@ -1,6 +1,7 @@
 #include "openbc/game_events.h"
 #include "openbc/buffer.h"
 #include "openbc/opcodes.h"
+#include "openbc/game_builders.h"
 #include <string.h>
 
 /*
@@ -480,6 +481,47 @@ bool bc_parse_delete_player_anim(const u8 *payload, int len,
     }
     out->player_name[copy_len] = '\0';
     out->name_len = copy_len;
+
+    return true;
+}
+
+/*
+ * ObjectExplodingEvent (PythonEvent 0x06, factory 0x8129)
+ *
+ * Wire format:
+ *   [0x06][factory:i32=0x8129][event_type:i32=0x4E]
+ *   [source_obj:i32][dest_obj:i32][killer_id:i32][lifetime:f32]
+ * 25 bytes total.
+ *
+ * Returns false (without error) for any PythonEvent whose factory ID is not
+ * the exploding-event factory, so a caller can pass every inbound 0x06 payload
+ * here as a cheap discriminator.
+ */
+bool bc_parse_python_exploding_event(const u8 *payload, int len,
+                                     bc_exploding_event_t *out)
+{
+    memset(out, 0, sizeof(*out));
+
+    bc_buffer_t buf;
+    bc_buf_init(&buf, (u8 *)payload, (size_t)len);
+
+    u8 opcode;
+    if (!bc_buf_read_u8(&buf, &opcode)) return false;
+    if (opcode != BC_OP_PYTHON_EVENT) return false;
+
+    i32 factory;
+    if (!bc_buf_read_i32(&buf, &factory)) return false;
+    if (factory != BC_FACTORY_OBJECT_EXPLODING) return false;
+
+    i32 event_type;
+    if (!bc_buf_read_i32(&buf, &event_type)) return false;
+    /* event_type is expected to be BC_EVENT_OBJECT_EXPLODING, but we do not
+     * reject other values: the factory ID alone identifies the kill signal. */
+
+    if (!bc_buf_read_i32(&buf, &out->source_object_id)) return false;
+    if (!bc_buf_read_i32(&buf, &out->dest_object_id)) return false;
+    if (!bc_buf_read_i32(&buf, &out->killer_id)) return false;
+    if (!bc_buf_read_f32(&buf, &out->lifetime)) return false;
 
     return true;
 }

--- a/tests/test_cloak_shield_delay.c
+++ b/tests/test_cloak_shield_delay.c
@@ -1,0 +1,169 @@
+/*
+ * test_cloak_shield_delay.c — Regression tests for Issue #192
+ *
+ * Wire-protocol trace analysis of a stock dedicated server session shows the
+ * shield-active state change is deferred by ShieldDelay (1.0s) relative to the
+ * cloak transition:
+ *
+ *   - Cloak-up: shields stay ACTIVE for the first ~1.0s (vulnerability window),
+ *     then go inactive — even though the cloak field begins rendering at t=0.
+ *   - Decloak: when the decloak transition completes the ship is fully visible
+ *     but shields stay INACTIVE for the first ~1.0s (grace window), then re-enable.
+ *
+ * These tests exercise the deferred timer in combat.c via the dt-based cloak
+ * state machine (bc_cloak_start / bc_cloak_tick / bc_cloak_shields_active).
+ */
+
+#include "test_util.h"
+#include "openbc/ship_data.h"
+#include "openbc/ship_state.h"
+#include "openbc/combat.h"
+#include "openbc/game_builders.h"
+#include <string.h>
+#include <math.h>
+
+#define REGISTRY_DIR "data/vanilla-1.1"
+
+static bc_game_registry_t g_reg;
+
+TEST(load_registry)
+{
+    ASSERT(bc_registry_load_dir(&g_reg, REGISTRY_DIR));
+}
+
+/* Find a cloak-capable ship class in the registry. */
+static const bc_ship_class_t *find_cloaker(void)
+{
+    for (int i = 0; i < g_reg.ship_count; i++) {
+        if (g_reg.ships[i].can_cloak) return &g_reg.ships[i];
+    }
+    return NULL;
+}
+
+/*
+ * #192-A: Fresh ship spawns with shields active and no pending change.
+ */
+TEST(spawn_shields_active)
+{
+    const bc_ship_class_t *cls = find_cloaker();
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 0, 0);
+
+    ASSERT(bc_cloak_shields_active(&ship));
+    ASSERT(ship.shield_delay_timer == 0.0f);
+}
+
+/*
+ * #192-B: Cloak-up vulnerability window.
+ * After bc_cloak_start, shields must remain ACTIVE for ~1.0s, then go inactive.
+ */
+TEST(cloak_up_vulnerability_window)
+{
+    const bc_ship_class_t *cls = find_cloaker();
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 0, 0);
+
+    ASSERT(bc_cloak_start(&ship, cls));
+    /* Immediately after cloak begins, shields are STILL up (vulnerability). */
+    ASSERT(bc_cloak_shields_active(&ship));
+
+    /* Advance 0.5s — still inside the 1.0s window: shields stay up. */
+    bc_cloak_tick(&ship, 1.0f, 0.5f);
+    ASSERT(bc_cloak_shields_active(&ship));
+
+    /* Advance past the 1.0s ShieldDelay (total 1.1s): shields now inactive. */
+    bc_cloak_tick(&ship, 1.0f, 0.6f);
+    ASSERT(!bc_cloak_shields_active(&ship));
+
+    /* Shield HP must be PRESERVED, not zeroed, through the transition. */
+    for (int i = 0; i < BC_MAX_SHIELD_FACINGS; i++)
+        ASSERT(ship.shield_hp[i] == cls->shield_hp[i]);
+}
+
+/*
+ * #192-C: Decloak grace window.
+ * After the decloak transition completes, the ship is fully visible but shields
+ * stay INACTIVE for ~1.0s, then re-enable.
+ */
+TEST(decloak_grace_window)
+{
+    const bc_ship_class_t *cls = find_cloaker();
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 0, 0);
+
+    /* Cloak fully: start + run through CloakTime + ShieldDelay. */
+    ASSERT(bc_cloak_start(&ship, cls));
+    bc_cloak_tick(&ship, 1.0f, BC_CLOAK_TRANSITION_TIME + BC_CLOAK_SHIELD_DELAY);
+    ASSERT(ship.cloak_state == BC_CLOAK_CLOAKED);
+    ASSERT(!bc_cloak_shields_active(&ship));
+
+    /* Begin decloak and run the full decloak transition (no ShieldDelay yet). */
+    ASSERT(bc_cloak_stop(&ship));
+    bc_cloak_tick(&ship, 1.0f, BC_CLOAK_TRANSITION_TIME);
+    ASSERT(ship.cloak_state == BC_CLOAK_DECLOAKED);
+
+    /* Decloak just completed: fully visible, but shields STILL down (grace). */
+    ASSERT(!bc_cloak_shields_active(&ship));
+
+    /* Advance 0.5s — still inside the grace window. */
+    bc_cloak_tick(&ship, 1.0f, 0.5f);
+    ASSERT(!bc_cloak_shields_active(&ship));
+
+    /* Advance past the 1.0s ShieldDelay (total 1.1s): shields re-enable. */
+    bc_cloak_tick(&ship, 1.0f, 0.6f);
+    ASSERT(bc_cloak_shields_active(&ship));
+}
+
+/*
+ * #192-D: Damage gate honors the deferred state.
+ * During the cloak-up vulnerability window shields must still absorb damage;
+ * after the window they must not.
+ */
+TEST(damage_gate_respects_delay)
+{
+    const bc_ship_class_t *cls = find_cloaker();
+    ASSERT(cls != NULL);
+
+    bc_vec3_t dir = { 0.0f, 1.0f, 0.0f }; /* front facing */
+
+    /* --- During vulnerability window: shields absorb (HP drops on a facing). */
+    {
+        bc_ship_state_t ship;
+        bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 0, 0);
+        ASSERT(bc_cloak_start(&ship, cls));        /* shields still up */
+        f32 front_before = ship.shield_hp[BC_SHIELD_FRONT];
+        ASSERT(front_before > 0.0f);
+        bc_combat_apply_damage(&ship, cls, 10.0f, 0.0f, dir, false, 1.0f);
+        ASSERT(ship.shield_hp[BC_SHIELD_FRONT] < front_before);
+    }
+
+    /* --- After window: shields inactive, hull takes the hit directly. */
+    {
+        bc_ship_state_t ship;
+        bc_ship_init(&ship, cls, 0, bc_make_ship_id(0), 0, 0);
+        ASSERT(bc_cloak_start(&ship, cls));
+        bc_cloak_tick(&ship, 1.0f, BC_CLOAK_SHIELD_DELAY + 0.1f); /* close window */
+        ASSERT(!bc_cloak_shields_active(&ship));
+
+        f32 front_before = ship.shield_hp[BC_SHIELD_FRONT];
+        f32 hull_before  = ship.hull_hp;
+        bc_combat_apply_damage(&ship, cls, 10.0f, 0.0f, dir, false, 1.0f);
+        /* Shields untouched (cloaked), hull absorbed the damage. */
+        ASSERT(ship.shield_hp[BC_SHIELD_FRONT] == front_before);
+        ASSERT(ship.hull_hp < hull_before);
+    }
+}
+
+TEST_MAIN_BEGIN()
+    RUN(load_registry);
+    RUN(spawn_shields_active);
+    RUN(cloak_up_vulnerability_window);
+    RUN(decloak_grace_window);
+    RUN(damage_gate_respects_delay);
+TEST_MAIN_END()

--- a/tests/test_dynamic_battle.c
+++ b/tests/test_dynamic_battle.c
@@ -285,7 +285,7 @@ static void ai_update(int idx, f32 dt)
 
         /* Try to repair while evading */
         bc_repair_auto_queue(&p->ship, p->cls);
-        bc_repair_tick(&p->ship, p->cls, dt);
+        bc_repair_tick(&p->ship, p->cls, dt, NULL, 0, NULL);
         if (p->ship.repair_count > 0) g_total_repairs++;
 
         /* Return to combat when shields recover */
@@ -297,7 +297,7 @@ static void ai_update(int idx, f32 dt)
 
     case AI_REPAIR:
         bc_repair_auto_queue(&p->ship, p->cls);
-        bc_repair_tick(&p->ship, p->cls, dt);
+        bc_repair_tick(&p->ship, p->cls, dt, NULL, 0, NULL);
         if (p->ship.repair_count > 0) g_total_repairs++;
 
         if (p->engage_timer > 5.0f || p->ship.repair_count == 0) {

--- a/tests/test_friendly_fire.c
+++ b/tests/test_friendly_fire.c
@@ -1,0 +1,127 @@
+/*
+ * test_friendly_fire.c — Regression tests for Issue #203
+ *
+ * Wire-protocol trace analysis of a stock dedicated server session shows the
+ * server maintains a cumulative friendly-fire (same-team) damage accumulator
+ * with a warning threshold (typically 100 points) and an optional tolerance
+ * ceiling that ends the game. The three configurable modes are:
+ *
+ *   PERMISSIVE — no tracking, no warnings, no game-over.
+ *   WARNING    — track + one-shot warning at warning_points; never end game.
+ *   STRICT     — track + warning + game-over once tolerance is exceeded.
+ *
+ * These tests exercise the pure accumulation/decision step bc_ff_step().
+ */
+
+#include "test_util.h"
+#include "openbc/combat.h"
+#include <string.h>
+
+static bc_friendly_fire_t make_ff(bc_ff_mode_t mode, f32 tol, f32 warn,
+                                  bool game_over)
+{
+    bc_friendly_fire_t ff;
+    memset(&ff, 0, sizeof(ff));
+    ff.mode = mode;
+    ff.tolerance = tol;
+    ff.warning_points = warn;
+    ff.current = 0.0f;
+    ff.game_over_on_threshold = game_over;
+    ff.warned = false;
+    return ff;
+}
+
+/*
+ * #203-A: PERMISSIVE mode is a no-op — no accumulation, no warnings.
+ */
+TEST(permissive_is_noop)
+{
+    bc_friendly_fire_t ff = make_ff(BC_FF_MODE_PERMISSIVE, 1000.0f, 100.0f, false);
+    bc_ff_outcome_t out = bc_ff_step(&ff, 500.0f);
+    ASSERT(!out.warned);
+    ASSERT(!out.game_over);
+    ASSERT(ff.current == 0.0f);
+    ASSERT(!ff.warned);
+}
+
+/*
+ * #203-B: WARNING mode accumulates and fires a one-shot warning at the
+ * threshold, but never reports game-over.
+ */
+TEST(warning_one_shot)
+{
+    bc_friendly_fire_t ff = make_ff(BC_FF_MODE_WARNING, 1000.0f, 100.0f, false);
+
+    /* Below threshold: accumulate, no warning. */
+    bc_ff_outcome_t o1 = bc_ff_step(&ff, 40.0f);
+    ASSERT(!o1.warned);
+    ASSERT(ff.current == 40.0f);
+
+    /* Crossing the threshold fires the warning exactly once. */
+    bc_ff_outcome_t o2 = bc_ff_step(&ff, 70.0f); /* current = 110 >= 100 */
+    ASSERT(o2.warned);
+    ASSERT(!o2.game_over);
+    ASSERT(ff.warned);
+
+    /* Further FF damage does NOT re-fire the warning (one-shot latch). */
+    bc_ff_outcome_t o3 = bc_ff_step(&ff, 2000.0f); /* far past tolerance too */
+    ASSERT(!o3.warned);
+    /* WARNING mode never ends the game even when tolerance is exceeded. */
+    ASSERT(!o3.game_over);
+}
+
+/*
+ * #203-C: STRICT mode ends the game once tolerance is exceeded.
+ */
+TEST(strict_ends_game)
+{
+    bc_friendly_fire_t ff = make_ff(BC_FF_MODE_STRICT, 1000.0f, 100.0f, true);
+
+    /* Warning fires at warning_points but no game-over yet. */
+    bc_ff_outcome_t o1 = bc_ff_step(&ff, 150.0f);
+    ASSERT(o1.warned);
+    ASSERT(!o1.game_over);
+
+    /* Below tolerance still: no game-over. */
+    bc_ff_outcome_t o2 = bc_ff_step(&ff, 500.0f); /* current = 650 */
+    ASSERT(!o2.game_over);
+
+    /* Exceed tolerance: game-over reported. */
+    bc_ff_outcome_t o3 = bc_ff_step(&ff, 500.0f); /* current = 1150 >= 1000 */
+    ASSERT(o3.game_over);
+}
+
+/*
+ * #203-D: Non-positive / invalid damage is ignored (no accumulation).
+ */
+TEST(ignores_non_positive)
+{
+    bc_friendly_fire_t ff = make_ff(BC_FF_MODE_WARNING, 1000.0f, 100.0f, false);
+    bc_ff_outcome_t o1 = bc_ff_step(&ff, 0.0f);
+    ASSERT(!o1.warned && ff.current == 0.0f);
+    bc_ff_outcome_t o2 = bc_ff_step(&ff, -50.0f);
+    ASSERT(!o2.warned && ff.current == 0.0f);
+}
+
+/*
+ * #203-E: A zero warning_points disables the warning emit (but accumulation
+ * still happens for the tolerance check in strict mode).
+ */
+TEST(zero_warning_points_no_warn)
+{
+    bc_friendly_fire_t ff = make_ff(BC_FF_MODE_STRICT, 200.0f, 0.0f, true);
+    bc_ff_outcome_t o1 = bc_ff_step(&ff, 150.0f);
+    ASSERT(!o1.warned);
+    ASSERT(!o1.game_over);
+    bc_ff_outcome_t o2 = bc_ff_step(&ff, 100.0f); /* current = 250 >= 200 */
+    ASSERT(!o2.warned);
+    ASSERT(o2.game_over);
+}
+
+TEST_MAIN_BEGIN()
+    RUN(permissive_is_noop);
+    RUN(warning_one_shot);
+    RUN(strict_ends_game);
+    RUN(ignores_non_positive);
+    RUN(zero_warning_points_no_warn);
+TEST_MAIN_END()

--- a/tests/test_game_builders.c
+++ b/tests/test_game_builders.c
@@ -488,6 +488,38 @@ TEST(event_forward_buffer_overflow)
     ASSERT(len == -1);
 }
 
+/* === Connect-event broadcast (#202) === */
+
+TEST(new_peer_connected_layout)
+{
+    u8 buf[32];
+    int len = bc_build_new_peer_connected(buf, sizeof(buf), 3);
+
+    ASSERT(len == 18);
+    ASSERT_EQ(buf[0], BC_OP_DELETE_PLAYER_UI);          /* 0x17 */
+    /* factory = 0x00000866 (LE) */
+    ASSERT_EQ(buf[1], 0x66);
+    ASSERT_EQ(buf[2], 0x08);
+    ASSERT_EQ(buf[3], 0x00);
+    ASSERT_EQ(buf[4], 0x00);
+    /* event = 0x00060007 (LE) -> ET_NEW_PEER_CONNECTED */
+    ASSERT_EQ(buf[5], 0x07);
+    ASSERT_EQ(buf[6], 0x00);
+    ASSERT_EQ(buf[7], 0x06);
+    ASSERT_EQ(buf[8], 0x00);
+    /* src = 0, tgt = 0 (8 zero bytes) */
+    for (int i = 9; i < 17; i++) ASSERT_EQ(buf[i], 0x00);
+    /* wire_peer_id */
+    ASSERT_EQ(buf[17], 3);
+}
+
+TEST(new_peer_connected_buffer_too_small)
+{
+    u8 buf[10]; /* needs 18 */
+    int len = bc_build_new_peer_connected(buf, sizeof(buf), 3);
+    ASSERT(len == -1);
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -548,4 +580,8 @@ TEST_MAIN_BEGIN()
     RUN(event_forward_add_repair_list);
     RUN(event_forward_repair_priority);
     RUN(event_forward_buffer_overflow);
+
+    /* Connect-event broadcast (#202) */
+    RUN(new_peer_connected_layout);
+    RUN(new_peer_connected_buffer_too_small);
 TEST_MAIN_END()

--- a/tests/test_game_events.c
+++ b/tests/test_game_events.c
@@ -532,6 +532,30 @@ TEST(exploding_event_truncated)
     ASSERT(!bc_parse_python_exploding_event(wire, wire_len - 1, &ev));
 }
 
+TEST(exploding_event_permissive_type)
+{
+    /* The parser identifies the kill signal by factory ID alone and must NOT
+     * reject a non-0x4E event_type field. Build a valid event, overwrite the
+     * event_type (offset 5..8, after the opcode byte + factory i32) with a
+     * bogus value, and confirm it still parses with fields intact. */
+    i32 killer_id = bc_make_ship_id(0);
+    i32 victim_id = bc_make_ship_id(1);
+
+    u8 wire[64];
+    int wire_len = bc_build_python_exploding_event(wire, sizeof(wire),
+                                                   killer_id, victim_id,
+                                                   killer_id, 9.5f);
+    ASSERT(wire_len == 25);
+
+    wire[5] = 0x99; wire[6] = 0x99; wire[7] = 0x99; wire[8] = 0x99;
+
+    bc_exploding_event_t ev;
+    ASSERT(bc_parse_python_exploding_event(wire, wire_len, &ev));
+    ASSERT_EQ((u32)ev.source_object_id, (u32)killer_id);
+    ASSERT_EQ((u32)ev.dest_object_id, (u32)victim_id);
+    ASSERT_EQ((u32)ev.killer_id, (u32)killer_id);
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -593,4 +617,5 @@ TEST_MAIN_BEGIN()
     RUN(exploding_event_rejects_other_factory);
     RUN(exploding_event_rejects_wrong_opcode);
     RUN(exploding_event_truncated);
+    RUN(exploding_event_permissive_type);
 TEST_MAIN_END()

--- a/tests/test_game_events.c
+++ b/tests/test_game_events.c
@@ -1,5 +1,6 @@
 #include "test_util.h"
 #include "openbc/game_events.h"
+#include "openbc/game_builders.h"
 #include "openbc/handshake.h"
 #include "openbc/buffer.h"
 #include "openbc/opcodes.h"
@@ -451,6 +452,86 @@ TEST(delete_player_anim_roundtrip)
     ASSERT(strcmp(ev.player_name, "TestPlayer") == 0);
 }
 
+/* === ObjectExplodingEvent parser (kill signal, PythonEvent factory 0x8129) === */
+
+TEST(exploding_event_weapon_kill)
+{
+    /* Killer (slot 0 ship) destroys victim (slot 1 ship). */
+    i32 killer_id = bc_make_ship_id(0);
+    i32 victim_id = bc_make_ship_id(1);
+
+    u8 wire[64];
+    int wire_len = bc_build_python_exploding_event(wire, sizeof(wire),
+                                                   killer_id, victim_id,
+                                                   killer_id, 9.5f);
+    ASSERT(wire_len == 25);
+
+    bc_exploding_event_t ev;
+    ASSERT(bc_parse_python_exploding_event(wire, wire_len, &ev));
+    ASSERT_EQ((u32)ev.source_object_id, (u32)killer_id);
+    ASSERT_EQ((u32)ev.dest_object_id, (u32)victim_id);
+    ASSERT_EQ((u32)ev.killer_id, (u32)killer_id);
+    ASSERT(ev.lifetime > 9.49f && ev.lifetime < 9.51f);
+}
+
+TEST(exploding_event_self_destruct)
+{
+    /* Self-destruct: no killer (source/killer = 0). */
+    i32 victim_id = bc_make_ship_id(2);
+
+    u8 wire[64];
+    int wire_len = bc_build_python_exploding_event(wire, sizeof(wire),
+                                                   0, victim_id, 0, 9.5f);
+    ASSERT(wire_len == 25);
+
+    bc_exploding_event_t ev;
+    ASSERT(bc_parse_python_exploding_event(wire, wire_len, &ev));
+    ASSERT_EQ_INT(ev.source_object_id, 0);
+    ASSERT_EQ((u32)ev.dest_object_id, (u32)victim_id);
+    ASSERT_EQ_INT(ev.killer_id, 0);
+}
+
+TEST(exploding_event_rejects_other_factory)
+{
+    /* A non-exploding PythonEvent (e.g. a subsystem event, factory 0x101)
+     * must be rejected so callers can use the parser as a discriminator. */
+    u8 wire[64];
+    int wire_len = bc_build_python_subsystem_event(wire, sizeof(wire),
+                                                   BC_EVENT_ADD_TO_REPAIR,
+                                                   bc_make_ship_id(0),
+                                                   bc_make_ship_id(1));
+    ASSERT(wire_len > 0);
+
+    bc_exploding_event_t ev;
+    ASSERT(!bc_parse_python_exploding_event(wire, wire_len, &ev));
+}
+
+TEST(exploding_event_rejects_wrong_opcode)
+{
+    /* Not a PythonEvent at all. */
+    u8 wire[8];
+    int wire_len = bc_build_destroy_obj(wire, sizeof(wire), bc_make_ship_id(0));
+    ASSERT(wire_len > 0);
+
+    bc_exploding_event_t ev;
+    ASSERT(!bc_parse_python_exploding_event(wire, wire_len, &ev));
+}
+
+TEST(exploding_event_truncated)
+{
+    i32 victim_id = bc_make_ship_id(1);
+    u8 wire[64];
+    int wire_len = bc_build_python_exploding_event(wire, sizeof(wire),
+                                                   bc_make_ship_id(0),
+                                                   victim_id,
+                                                   bc_make_ship_id(0), 9.5f);
+    ASSERT(wire_len == 25);
+
+    /* Drop the trailing lifetime float -> truncated. */
+    bc_exploding_event_t ev;
+    ASSERT(!bc_parse_python_exploding_event(wire, wire_len - 1, &ev));
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -505,4 +586,11 @@ TEST_MAIN_BEGIN()
     RUN(delete_player_anim_wrong_opcode);
     RUN(delete_player_anim_too_short);
     RUN(delete_player_anim_roundtrip);
+
+    /* ObjectExplodingEvent (kill signal, PythonEvent factory 0x8129) */
+    RUN(exploding_event_weapon_kill);
+    RUN(exploding_event_self_destruct);
+    RUN(exploding_event_rejects_other_factory);
+    RUN(exploding_event_rejects_wrong_opcode);
+    RUN(exploding_event_truncated);
 TEST_MAIN_END()

--- a/tests/test_join_flow.c
+++ b/tests/test_join_flow.c
@@ -287,19 +287,35 @@ TEST(join_sends_delete_player_ui_to_others)
     CHECK(test_client_connect(&cli2, JF_PORT + 1, "Player2", 0, GAME_DIR));
     cli2_ok = true;
 
-    /* First client should receive DeletePlayerUI (0x17) for the second player */
+    /* First client should receive DeletePlayerUI (0x17) for the second player.
+     *
+     * Two distinct 0x17 messages now arrive for a join:
+     *   1. The connect-event broadcast (#202), carrying event_code
+     *      BC_EVENT_NEW_PEER_CONNECTED (0x00060007), fired at transport
+     *      connect time -- before checksum exchange.
+     *   2. The NewPlayerInGame player-list add, carrying event_code
+     *      BC_EVENT_NEW_PLAYER (0x008000F1).
+     * Both are valid; this test targets the NEW_PLAYER one, so scan past any
+     * connect-event 0x17 until the NEW_PLAYER-coded message is found. */
     int msg_len = 0;
-    const u8 *msg = test_client_expect_opcode(&cli1, BC_OP_DELETE_PLAYER_UI,
-                                               &msg_len, 2000);
-    CHECK(msg != NULL);
-    CHECK(msg_len == 18);
-
-    /* Verify it's a NEW_PLAYER event */
-    i32 event_code = read_i32_le(msg + 5);
-    CHECK(event_code == (i32)BC_EVENT_NEW_PLAYER);
+    i32 event_code = 0;
+    u8 wire_peer = 0;
+    bool found_new_player = false;
+    for (int attempt = 0; attempt < 8 && !found_new_player; attempt++) {
+        const u8 *msg = test_client_expect_opcode(&cli1, BC_OP_DELETE_PLAYER_UI,
+                                                   &msg_len, 2000);
+        CHECK(msg != NULL);
+        CHECK(msg_len == 18);
+        event_code = read_i32_le(msg + 5);
+        wire_peer  = msg[17];
+        if (event_code == (i32)BC_EVENT_NEW_PLAYER)
+            found_new_player = true;
+        else
+            CHECK(event_code == (i32)BC_EVENT_NEW_PEER_CONNECTED);
+    }
+    CHECK(found_new_player);
 
     /* Wire peer ID should be the second player's wire slot */
-    u8 wire_peer = msg[17];
     CHECK(wire_peer == 3);  /* peer_slot=2 -> wire_slot=3 */
 
 cleanup2:

--- a/tests/test_master_txt.c
+++ b/tests/test_master_txt.c
@@ -1,0 +1,161 @@
+#include "test_util.h"
+#include "openbc/master.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* -------------------------------------------------------------------------
+ * masterserver.txt parser tests (#201)
+ *
+ * bc_master_parse_txt() reads a masterserver.txt-style file (one "host:port"
+ * per line, '#' comments, blank lines skipped) into a caller buffer. These
+ * tests exercise the parser purely from disk -- no DNS, no sockets.
+ * ---------------------------------------------------------------------- */
+
+/* Write text to a temp file; returns the path (static buffer). */
+static const char *write_temp(const char *content)
+{
+    static char path[] = "obc_master_txt_test.tmp";
+    FILE *f = fopen(path, "wb");
+    if (!f) return NULL;
+    fwrite(content, 1, strlen(content), f);
+    fclose(f);
+    return path;
+}
+
+static void remove_temp(const char *path)
+{
+    if (path) remove(path);
+}
+
+TEST(parse_simple_two_entries)
+{
+    const char *path = write_temp(
+        "masterserver.example.com:27900\n"
+        "backup.example.com:27900\n");
+    ASSERT(path != NULL);
+
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt(path, out, BC_MASTERSERVER_TXT_MAX);
+    remove_temp(path);
+
+    ASSERT_EQ_INT(n, 2);
+    ASSERT(strcmp(out[0], "masterserver.example.com:27900") == 0);
+    ASSERT(strcmp(out[1], "backup.example.com:27900") == 0);
+}
+
+TEST(comments_and_blanks_skipped)
+{
+    const char *path = write_temp(
+        "# this is a comment\n"
+        "\n"
+        "   \t  \n"
+        "  # indented comment\n"
+        "master.example.com:27900\n"
+        "\n"
+        "# trailing comment\n");
+    ASSERT(path != NULL);
+
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt(path, out, BC_MASTERSERVER_TXT_MAX);
+    remove_temp(path);
+
+    ASSERT_EQ_INT(n, 1);
+    ASSERT(strcmp(out[0], "master.example.com:27900") == 0);
+}
+
+TEST(whitespace_and_crlf_trimmed)
+{
+    /* CRLF line endings + surrounding whitespace must be trimmed. */
+    const char *path = write_temp(
+        "   master.example.com:27900   \r\n"
+        "\tbackup.example.com:28900\t\r\n");
+    ASSERT(path != NULL);
+
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt(path, out, BC_MASTERSERVER_TXT_MAX);
+    remove_temp(path);
+
+    ASSERT_EQ_INT(n, 2);
+    ASSERT(strcmp(out[0], "master.example.com:27900") == 0);
+    ASSERT(strcmp(out[1], "backup.example.com:28900") == 0);
+}
+
+TEST(inline_trailing_comment_stripped)
+{
+    const char *path = write_temp(
+        "master.example.com:27900  # primary master\n");
+    ASSERT(path != NULL);
+
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt(path, out, BC_MASTERSERVER_TXT_MAX);
+    remove_temp(path);
+
+    ASSERT_EQ_INT(n, 1);
+    ASSERT(strcmp(out[0], "master.example.com:27900") == 0);
+}
+
+TEST(first_line_wins_ordering)
+{
+    /* Older "first non-comment line wins" consumers read out[0]. */
+    const char *path = write_temp(
+        "# header\n"
+        "primary.example.com:27900\n"
+        "secondary.example.com:27900\n");
+    ASSERT(path != NULL);
+
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt(path, out, BC_MASTERSERVER_TXT_MAX);
+    remove_temp(path);
+
+    ASSERT(n >= 1);
+    ASSERT(strcmp(out[0], "primary.example.com:27900") == 0);
+}
+
+TEST(missing_file_returns_negative)
+{
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt("this_file_does_not_exist_obc.tmp",
+                                out, BC_MASTERSERVER_TXT_MAX);
+    ASSERT(n < 0);
+}
+
+TEST(respects_max_out_cap)
+{
+    const char *path = write_temp(
+        "a.example.com:27900\n"
+        "b.example.com:27900\n"
+        "c.example.com:27900\n");
+    ASSERT(path != NULL);
+
+    char out[2][128];
+    int n = bc_master_parse_txt(path, out, 2);
+    remove_temp(path);
+
+    ASSERT_EQ_INT(n, 2);
+    ASSERT(strcmp(out[0], "a.example.com:27900") == 0);
+    ASSERT(strcmp(out[1], "b.example.com:27900") == 0);
+}
+
+TEST(empty_file_returns_zero)
+{
+    const char *path = write_temp("");
+    ASSERT(path != NULL);
+
+    char out[BC_MASTERSERVER_TXT_MAX][128];
+    int n = bc_master_parse_txt(path, out, BC_MASTERSERVER_TXT_MAX);
+    remove_temp(path);
+
+    ASSERT_EQ_INT(n, 0);
+}
+
+TEST_MAIN_BEGIN()
+    RUN(parse_simple_two_entries);
+    RUN(comments_and_blanks_skipped);
+    RUN(whitespace_and_crlf_trimmed);
+    RUN(inline_trailing_comment_stripped);
+    RUN(first_line_wins_ordering);
+    RUN(missing_file_returns_negative);
+    RUN(respects_max_out_cap);
+    RUN(empty_file_returns_zero);
+TEST_MAIN_END()

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -692,12 +692,15 @@ TEST(cloak_full_cycle)
 
     /* Can't fire while cloaking */
     ASSERT(!bc_cloak_can_fire(&ship));
-    ASSERT(!bc_cloak_shields_active(&ship));
+    /* Issue #192: cloak-up vulnerability window — shields stay ACTIVE for the
+     * first ShieldDelay (1.0s) of the transition. */
+    ASSERT(bc_cloak_shields_active(&ship));
 
-    /* Tick through transition */
+    /* Tick through transition (exceeds ShieldDelay) → shields now inactive. */
     bc_cloak_tick(&ship, /* cloak_efficiency */ 1.0f,
                   /* dt */ BC_CLOAK_TRANSITION_TIME + 0.1f);
     ASSERT_EQ((int)ship.cloak_state, BC_CLOAK_CLOAKED);
+    ASSERT(!bc_cloak_shields_active(&ship));
 
     /* Still can't fire while cloaked */
     ASSERT(!bc_cloak_can_fire(&ship));
@@ -710,13 +713,20 @@ TEST(cloak_full_cycle)
     ASSERT(!bc_cloak_can_fire(&ship));
     ASSERT(!bc_cloak_shields_active(&ship));
 
-    /* Tick through decloak transition */
+    /* Tick through decloak transition (does NOT consume the post-decloak
+     * ShieldDelay — that timer is armed on the completing tick). */
     bc_cloak_tick(&ship, /* cloak_efficiency */ 1.0f,
                   /* dt */ BC_CLOAK_TRANSITION_TIME + 0.1f);
     ASSERT_EQ((int)ship.cloak_state, BC_CLOAK_DECLOAKED);
 
-    /* Now can fire and shields active again */
+    /* Can fire again immediately, but Issue #192 decloak grace window keeps
+     * shields down for the first ShieldDelay (1.0s) of full visibility. */
     ASSERT(bc_cloak_can_fire(&ship));
+    ASSERT(!bc_cloak_shields_active(&ship));
+
+    /* Advance past the ShieldDelay grace window → shields re-enable. */
+    bc_cloak_tick(&ship, /* cloak_efficiency */ 1.0f,
+                  /* dt */ BC_CLOAK_SHIELD_DELAY + 0.1f);
     ASSERT(bc_cloak_shields_active(&ship));
 }
 
@@ -743,8 +753,14 @@ TEST(cloak_auto_decloak_on_low_power)
                   /* dt */ BC_CLOAK_TRANSITION_TIME + 0.1f);
     ASSERT_EQ((int)ship.cloak_state, BC_CLOAK_DECLOAKED);
 
-    /* Fully decloaked: can fire and shields active */
+    /* Fully decloaked: can fire immediately. Issue #192 grace window keeps
+     * shields down for the first ShieldDelay (1.0s) of full visibility. */
     ASSERT(bc_cloak_can_fire(&ship));
+    ASSERT(!bc_cloak_shields_active(&ship));
+
+    /* Advance past the ShieldDelay grace window → shields re-enable. */
+    bc_cloak_tick(&ship, /* cloak_efficiency */ 0.0f,
+                  /* dt */ BC_CLOAK_SHIELD_DELAY + 0.1f);
     ASSERT(bc_cloak_shields_active(&ship));
 }
 

--- a/tests/test_registry.c
+++ b/tests/test_registry.c
@@ -935,7 +935,7 @@ TEST(repair_heals_subsystem)
     ASSERT_EQ(ship.repair_count, 1);
 
     f32 before = ship.subsystem_hp[0];
-    bc_repair_tick(&ship, cls, 1.0f);
+    bc_repair_tick(&ship, cls, 1.0f, NULL, 0, NULL);
     ASSERT(ship.subsystem_hp[0] > before); /* healed */
 }
 
@@ -951,7 +951,7 @@ TEST(repair_removes_when_full)
 
     bc_repair_add(&ship, 0);
     /* Repair for long time -> should fully heal and auto-remove */
-    bc_repair_tick(&ship, cls, 100.0f);
+    bc_repair_tick(&ship, cls, 100.0f, NULL, 0, NULL);
     ASSERT(ship.subsystem_hp[0] >= max_hp - 0.01f);
     ASSERT_EQ(ship.repair_count, 0); /* removed from queue */
 }

--- a/tests/test_repair_completion_events.c
+++ b/tests/test_repair_completion_events.c
@@ -1,0 +1,179 @@
+/* Repair-tick wire-event emission tests.
+ *
+ * Wire-protocol trace analysis of a stock dedicated server session shows the
+ * host announces repair-queue transitions to clients as PythonEvent (0x06):
+ *   - REPAIR_COMPLETED (0x00800074): subsystem reached max condition.
+ *     Factory 0x0101 base TGEvent (17 bytes on wire).
+ *   - REPAIR_CANNOT_BE_COMPLETED (0x00800075): subsystem destroyed while
+ *     queued. Factory 0x010C TGObjPtrEvent (21 bytes on wire).
+ *
+ * These tests verify bc_repair_tick() reports those transitions through its
+ * out-parameter (the simulation side) and that the matching builders produce
+ * the expected wire bytes (the protocol side). */
+
+#include "test_util.h"
+#include "openbc/ship_data.h"
+#include "openbc/ship_state.h"
+#include "openbc/combat.h"
+#include "openbc/game_builders.h"
+#include "openbc/opcodes.h"
+#include <string.h>
+
+#define REGISTRY_DIR "data/vanilla-1.1"
+
+static bc_game_registry_t g_reg;
+
+static i32 rd_i32(const u8 *p)
+{
+    return (i32)((u32)p[0] | ((u32)p[1] << 8) |
+                 ((u32)p[2] << 16) | ((u32)p[3] << 24));
+}
+
+TEST(load_registry)
+{
+    memset(&g_reg, 0, sizeof(g_reg));
+    ASSERT(bc_registry_load_dir(&g_reg, REGISTRY_DIR));
+    ASSERT(g_reg.ship_count > 0);
+}
+
+/* A queued subsystem that finishes repair reports a COMPLETED event and is
+ * dropped from the queue. */
+TEST(repair_completed_emits_event)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3); /* Galaxy */
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    /* Almost-full subsystem; a long tick completes the repair. */
+    f32 max_hp = cls->subsystems[0].max_condition;
+    ASSERT(max_hp > 0.0f);
+    ship.subsystem_hp[0] = max_hp - 1.0f;
+    ASSERT(bc_repair_add(&ship, 0));
+
+    bc_repair_event_t evts[BC_MAX_SUBSYSTEMS];
+    int n = -1;
+    bc_repair_tick(&ship, cls, 100.0f, evts, BC_MAX_SUBSYSTEMS, &n);
+
+    ASSERT_EQ(n, 1);
+    ASSERT_EQ(evts[0].subsys_index, 0);
+    ASSERT_EQ(evts[0].kind, BC_REPAIR_EVT_COMPLETED);
+    ASSERT_EQ(ship.repair_count, 0);          /* dropped from queue */
+    ASSERT(ship.subsystem_hp[0] >= max_hp - 0.01f);
+}
+
+/* A queued subsystem that drops to 0 HP while waiting reports a CANNOT event
+ * and is dropped from the queue (previously a silent skip that left the entry
+ * stuck in the queue forever). */
+TEST(repair_destroyed_emits_cannot)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3); /* Galaxy */
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    /* Queue a subsystem, then destroy it (0 HP) before the next tick. */
+    ship.subsystem_hp[1] = cls->subsystems[1].max_condition * 0.5f;
+    ASSERT(bc_repair_add(&ship, 1));
+    ship.subsystem_hp[1] = 0.0f; /* destroyed while queued */
+
+    bc_repair_event_t evts[BC_MAX_SUBSYSTEMS];
+    int n = -1;
+    bc_repair_tick(&ship, cls, 1.0f, evts, BC_MAX_SUBSYSTEMS, &n);
+
+    ASSERT_EQ(n, 1);
+    ASSERT_EQ(evts[0].subsys_index, 1);
+    ASSERT_EQ(evts[0].kind, BC_REPAIR_EVT_CANNOT);
+    ASSERT_EQ(ship.repair_count, 0); /* dropped, no longer stuck */
+}
+
+/* An in-progress repair (not yet complete, not destroyed) reports no event. */
+TEST(repair_in_progress_no_event)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    bc_ship_assign_subsystem_ids(&ship, cls);
+
+    ship.subsystem_hp[0] = cls->subsystems[0].max_condition * 0.1f;
+    ASSERT(bc_repair_add(&ship, 0));
+
+    bc_repair_event_t evts[BC_MAX_SUBSYSTEMS];
+    int n = -1;
+    /* Small dt: heals a little but does not complete. */
+    bc_repair_tick(&ship, cls, 0.01f, evts, BC_MAX_SUBSYSTEMS, &n);
+
+    ASSERT_EQ(n, 0);
+    ASSERT_EQ(ship.repair_count, 1); /* still queued */
+}
+
+/* NULL out-parameters are tolerated (existing callers that don't want events). */
+TEST(repair_tick_null_outparams)
+{
+    const bc_ship_class_t *cls = bc_registry_find_ship(&g_reg, 3);
+    ASSERT(cls != NULL);
+
+    bc_ship_state_t ship;
+    bc_ship_init(&ship, cls, 2, bc_make_ship_id(0), 0, 0);
+    f32 max_hp = cls->subsystems[0].max_condition;
+    ship.subsystem_hp[0] = max_hp - 1.0f;
+    ASSERT(bc_repair_add(&ship, 0));
+
+    bc_repair_tick(&ship, cls, 100.0f, NULL, 0, NULL);
+    ASSERT_EQ(ship.repair_count, 0); /* still drops the completed entry */
+}
+
+/* REPAIR_COMPLETED wire bytes: opcode 0x06, factory 0x0101, event 0x00800074. */
+TEST(repair_completed_wire_format)
+{
+    u8 buf[32];
+    int len = bc_build_python_subsystem_event(
+        buf, sizeof(buf),
+        BC_EVENT_REPAIR_COMPLETED,
+        0x40010001, /* repair subsystem obj id (source) */
+        0x40010005  /* repaired subsystem obj id (dest) */);
+
+    ASSERT_EQ(len, 17);
+    ASSERT_EQ(buf[0], BC_OP_PYTHON_EVENT);
+    ASSERT_EQ((u32)rd_i32(&buf[1]), (u32)BC_FACTORY_SUBSYSTEM_EVENT); /* 0x0101 */
+    ASSERT_EQ((u32)rd_i32(&buf[5]), (u32)BC_EVENT_REPAIR_COMPLETED);  /* 0x00800074 */
+    ASSERT_EQ((u32)rd_i32(&buf[9]), 0x40010001u);
+    ASSERT_EQ((u32)rd_i32(&buf[13]), 0x40010005u);
+}
+
+/* REPAIR_CANNOT_BE_COMPLETED wire bytes: opcode 0x06, factory 0x010C,
+ * event 0x00800075, plus the trailing obj_ptr int32. */
+TEST(repair_cannot_wire_format)
+{
+    u8 buf[32];
+    int len = bc_build_python_obj_ptr_event(
+        buf, sizeof(buf),
+        BC_EVENT_REPAIR_CANNOT,
+        0x40010001, /* repair subsystem obj id (source) */
+        0x40010007, /* destroyed subsystem obj id (dest) */
+        0x40010007  /* obj_ptr = subsystem obj id */);
+
+    ASSERT_EQ(len, 21);
+    ASSERT_EQ(buf[0], BC_OP_PYTHON_EVENT);
+    ASSERT_EQ((u32)rd_i32(&buf[1]), (u32)BC_FACTORY_OBJ_PTR_EVENT); /* 0x010C */
+    ASSERT_EQ((u32)rd_i32(&buf[5]), (u32)BC_EVENT_REPAIR_CANNOT);   /* 0x00800075 */
+    ASSERT_EQ((u32)rd_i32(&buf[9]), 0x40010001u);
+    ASSERT_EQ((u32)rd_i32(&buf[13]), 0x40010007u);
+    ASSERT_EQ((u32)rd_i32(&buf[17]), 0x40010007u);
+}
+
+TEST_MAIN_BEGIN()
+    RUN(load_registry);
+    RUN(repair_completed_emits_event);
+    RUN(repair_destroyed_emits_cannot);
+    RUN(repair_in_progress_no_event);
+    RUN(repair_tick_null_outparams);
+    RUN(repair_completed_wire_format);
+    RUN(repair_cannot_wire_format);
+TEST_MAIN_END()

--- a/tests/test_serialization_parity.c
+++ b/tests/test_serialization_parity.c
@@ -388,6 +388,51 @@ TEST(flat_count_matches_authored_tree)
     }
 }
 
+/* flat_count_matches_authored_tree pairs registry index i with SHIP_FOLDERS[i],
+ * which only holds if the registry loads ships in SHIP_FOLDERS order. That order
+ * comes from the manifest, so verify SHIP_FOLDERS matches the manifest's ship
+ * enumeration exactly -- if the manifest is reordered, fail loudly here instead
+ * of silently comparing mismatched ship/folder pairs downstream. */
+TEST(ship_folders_match_manifest_order)
+{
+    char path[512];
+    snprintf(path, sizeof(path), "%s/manifest.json", REGISTRY_DIR);
+
+    FILE *f = fopen(path, "rb");
+    ASSERT(f != NULL);
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    ASSERT(sz > 0);
+    char *buf = (char *)malloc((size_t)sz + 1);
+    ASSERT(buf != NULL);
+    size_t rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[rd] = '\0';
+
+    json_value_t *root = json_parse(buf);
+    free(buf);
+    ASSERT(root != NULL);
+
+    const json_value_t *ships = json_get(root, "ships");
+    ASSERT(ships != NULL && ships->type == JSON_ARRAY);
+    ASSERT((int)json_array_len(ships) == SHIP_FOLDER_COUNT);
+
+    for (int i = 0; i < SHIP_FOLDER_COUNT; i++) {
+        const json_value_t *e = json_array_get(ships, (size_t)i);
+        ASSERT(e != NULL && e->type == JSON_STRING);
+        const char *folder = json_string(e);
+        if (!folder || strcmp(folder, SHIP_FOLDERS[i]) != 0) {
+            printf("FAIL\n    manifest ship[%d]='%s' != SHIP_FOLDERS[%d]='%s'\n",
+                   i, folder ? folder : "(null)", i, SHIP_FOLDERS[i]);
+            test_fail++; test_pass--;
+            json_free(root);
+            return;
+        }
+    }
+    json_free(root);
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -402,4 +447,5 @@ TEST_MAIN_BEGIN()
     RUN(oversized_tree_never_emits_oob_hp_index);
     RUN(all_ships_hp_index_in_range);
     RUN(flat_count_matches_authored_tree);
+    RUN(ship_folders_match_manifest_order);
 TEST_MAIN_END()

--- a/tests/test_serialization_parity.c
+++ b/tests/test_serialization_parity.c
@@ -14,10 +14,13 @@
  */
 #include "test_util.h"
 #include "openbc/ship_data.h"
+#include "openbc/json_parse.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define REGISTRY_DIR  "data/vanilla-1.1"
+#define SHIPS_DIR     REGISTRY_DIR "/ships"
 
 static bc_game_registry_t g_reg;
 
@@ -271,6 +274,120 @@ TEST(oversized_tree_never_emits_oob_hp_index)
     }
 }
 
+/* === Registry-wide regression guards (cover ALL loaded ships) ===
+ *
+ * The EXPECTED[] table above keys off species_id and only enumerates the 15
+ * combat ships.  The two tests below instead iterate the FULL loaded registry
+ * (every ship folder in the manifest, including non-combat hulls such as the
+ * Cardassian freighter) so a newly added or re-authored ship cannot slip past
+ * the parity checks.  They are the per-ship guards required by #205's
+ * verification item: confirm the flattened order is sane for every ship, not
+ * just galaxy. */
+
+/* Independently recompute the expected FLATTENED top-level entry count straight
+ * from a ship's serialization.json authoring tree: one entry per parent plus
+ * one per child mount.  This is the count the loader MUST produce after
+ * promoting every weapon mount / nacelle to its own top-level entry.  If a
+ * future change regressed to nesting (children left under a parent), the loader
+ * count would drop below this value and the test would fail. */
+static int authored_flat_count(const char *ship_folder)
+{
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s/serialization.json", SHIPS_DIR, ship_folder);
+
+    FILE *f = fopen(path, "rb");
+    if (!f) return -1;
+    fseek(f, 0, SEEK_END);
+    long sz = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (sz <= 0) { fclose(f); return -1; }
+    char *buf = (char *)malloc((size_t)sz + 1);
+    if (!buf) { fclose(f); return -1; }
+    size_t rd = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    buf[rd] = '\0';
+
+    json_value_t *arr = json_parse(buf);
+    free(buf);
+    if (!arr || arr->type != JSON_ARRAY) { json_free(arr); return -1; }
+
+    int total = 0;
+    size_t n = json_array_len(arr);
+    for (size_t i = 0; i < n; i++) {
+        const json_value_t *e = json_array_get(arr, i);
+        total += 1; /* the parent entry itself */
+        const json_value_t *children = json_get(e, "children");
+        if (children && children->type == JSON_ARRAY)
+            total += (int)json_array_len(children); /* each mount -> own entry */
+    }
+    json_free(arr);
+    return total;
+}
+
+/* The manifest folder list, matched 1:1 to load order so authored_flat_count()
+ * can be cross-checked against the corresponding loaded ship class. */
+static const char *const SHIP_FOLDERS[] = {
+    "akira", "ambassador", "galaxy", "nebula", "sovereign", "birdofprey",
+    "vorcha", "warbird", "marauder", "galor", "keldon", "cardhybrid",
+    "kessokheavy", "kessoklight", "shuttle", "cardfreighter",
+};
+#define SHIP_FOLDER_COUNT (int)(sizeof(SHIP_FOLDERS) / sizeof(SHIP_FOLDERS[0]))
+
+TEST(all_ships_hp_index_in_range)
+{
+    /* Core OOB guard: for EVERY loaded ship, no flattened entry may carry an
+     * hp_index outside the addressable HP-slot range.  subsystem_hp[] has
+     * exactly BC_MAX_SUBSYSTEMS slots; synthetic containers legitimately use
+     * slots in [subsystem_count, total_hp_slots).  An out-of-range hp_index
+     * would corrupt unrelated memory at StateUpdate time. */
+    ASSERT(g_reg.ship_count > 0);
+    for (int i = 0; i < g_reg.ship_count; i++) {
+        const bc_ship_class_t *cls = bc_registry_get_ship(&g_reg, i);
+        ASSERT(cls != NULL);
+        const bc_ss_list_t *sl = &cls->ser_list;
+
+        ASSERT(sl->count <= BC_SS_MAX_ENTRIES);
+        ASSERT(sl->total_hp_slots <= BC_MAX_SUBSYSTEMS);
+
+        for (int j = 0; j < sl->count; j++) {
+            int hp = sl->entries[j].hp_index;
+            if (hp < 0 || hp >= sl->total_hp_slots || hp >= BC_MAX_SUBSYSTEMS) {
+                printf("FAIL\n    ship '%s' entry %d: hp_index=%d "
+                       "(total_hp_slots=%d, max=%d)\n",
+                       cls->name, j, hp, sl->total_hp_slots, BC_MAX_SUBSYSTEMS);
+                test_fail++; test_pass--;
+                return;
+            }
+            /* The runtime list is flat: children must already be promoted. */
+            ASSERT_EQ_INT(sl->entries[j].child_count, 0);
+        }
+    }
+}
+
+TEST(flat_count_matches_authored_tree)
+{
+    /* For every ship folder, the loader's flattened entry count must equal the
+     * authored (parents + mounts) count.  A regression to nesting would make
+     * the loaded count smaller than the authored count -- caught here without
+     * relying on the hand-maintained EXPECTED[] table. */
+    ASSERT_EQ_INT(g_reg.ship_count, SHIP_FOLDER_COUNT);
+    for (int i = 0; i < SHIP_FOLDER_COUNT; i++) {
+        const bc_ship_class_t *cls = bc_registry_get_ship(&g_reg, i);
+        ASSERT(cls != NULL);
+
+        int authored = authored_flat_count(SHIP_FOLDERS[i]);
+        ASSERT(authored > 0);
+
+        if (cls->ser_list.count != authored) {
+            printf("FAIL\n    ship '%s' (folder '%s'): loaded flat count=%d, "
+                   "authored flat count=%d\n",
+                   cls->name, SHIP_FOLDERS[i], cls->ser_list.count, authored);
+            test_fail++; test_pass--;
+            return;
+        }
+    }
+}
+
 /* === Run all tests === */
 
 TEST_MAIN_BEGIN()
@@ -283,4 +400,6 @@ TEST_MAIN_BEGIN()
     RUN(start_idx_reaches_weapon_indices);
     RUN(reactor_entry_format_is_power);
     RUN(oversized_tree_never_emits_oob_hp_index);
+    RUN(all_ships_hp_index_in_range);
+    RUN(flat_count_matches_authored_tree);
 TEST_MAIN_END()


### PR DESCRIPTION
## Summary

Batch implementation of the issues filed on 2026-05-29, integrated from five isolated worktree branches into one PR. Each branch was built and tested in isolation; this branch is the merged result with all conflicts resolved.

**36/36 tests pass** (build clean, no new warnings). Includes 6 new test files.

## Issues closed

| Issue | Title | Notes |
|-------|-------|-------|
| #188 | Weapon-kill SCORE_CHANGE not emitted | Inbound `ObjectExplodingEvent` parsed as a **guarded fallback** kill detector (see note below) |
| #189 | 0x06 PythonEvent over-relay | Inbound `0x06` no longer relayed verbatim; absorbed locally |
| #190 | Repair tick silently drops completed/destroyed subsystems | `bc_repair_tick` now reports queue transitions; emits REPAIR_COMPLETED (0x0101) / REPAIR_CANNOT (0x010C); destroyed-while-queued subsystems dropped from queue |
| #191 | 0x29 Explosion emitted per-tick | Per-tick beam/torpedo-kill `0x29` emission removed; OBJECT_EXPLODING remains the death visual |
| #192 | ShieldDelay 1.0s window on cloak transitions | Deferred shield-state timer; ~1s vulnerability window on cloak-up, ~1s grace on decloak; shield HP preserved |
| #201 | masterserver.txt runtime override | `host:port` per line, `#` comments; precedence CLI/TOML > txt > baked-in default |
| #202 | Connect-event broadcast on new peer join | Fires `player_connected` event-bus event + broadcasts `ET_NEW_PEER_CONNECTED` (0x00060007) |
| #203 | Friendly-fire tracking + warning points | Three-value model + permissive/warning/strict modes, configurable in server.toml |
| #205 | Subsystem serialization order/format divergence | Code fixes already shipped in #204; this adds registry-wide flat-ser_list regression tests for all 16 stock ships (all verified already-flat) |

## Already shipped (close separately, not in this PR)

While implementing the score/game-flow bundle, **#196 (MISSION_INIT 0x35), #197 (SCORE 0x37 roster sync), #198 (END_GAME 0x38), and #199 (RESTART_GAME 0x39) were found already implemented** in `main` and verified intact. They can be closed as already-done.

**#200 (TEAM_DM)** is also already implemented, but the existing code's `0x3F`/`0x41` wire layout **differs from the format described in the issue** (existing: 0x41 = team assignment, 0x3F = 5-field score-init). The working/tested implementation was respected rather than rewritten — **flagging for a decision** on whether the issue's described layout or the shipped one is correct (needs trace verification).

## Reconciliation note — the 0x06 handler (#188 ⇄ #189)

The two relevant branches edited the same `BC_OP_PYTHON_EVENT` case with **contradictory premises**:
- #189: inbound `0x06` is server-originated (claims ~zero client→server occurrences) → absorb, don't relay.
- #188: the victim's client emits `ObjectExplodingEvent` on death → host must observe it to attribute kills.

These cannot both be literally true. Resolved to the **superset that is safe under either premise**: parse the inbound exploding-event as a *guarded fallback* kill detector (fires only when the server has not already retired the victim, so no double-count) **and** do not relay `0x06` verbatim (the duplicate-event fix from #189 stays). If clients never send `0x06`, the fallback block simply never runs — no regression.

**OPEN (needs live trace verification):** the actual frequency of client- vs server-originated `0x06`, and whether bystanders need a server-re-originated `OBJECT_EXPLODING` in the fallback-kill case or self-trigger the death visual from the hull-zero StateUpdate. Documented inline in `server_dispatch.c`.

## Deferred

**#195 (4-pass packet bundling)** is intentionally not in this batch — it's a ~200-LoC architectural rework of the send path (with the ACK-outbox deadlock gate) that warrants its own focused PR and carries interop risk if rushed.

## Test plan

- [x] `make PLATFORM=Linux` clean, no new warnings
- [x] `make test PLATFORM=Linux` — 36 passed, 0 failed
- [ ] Live verification of the #188/#189 `0x06` open question against stock-client traces
- [ ] Decision on #200 TEAM_DM wire layout (issue format vs shipped format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloak transitions now include shield delay windows (vulnerability/grace).
  * Friendly-fire tracking with configurable modes, warnings, and optional game-over.
  * Repair subsystem emits per-subsystem completion/failure events.
  * Server can load masterserver.txt entries and broadcasts peer-connected notifications.

* **Bug Fixes**
  * Shield recharge/reliability refined to follow deferred cloak/shield state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SandboxServers/OpenBC/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->